### PR TITLE
Change audio sink to autoaudiosink

### DIFF
--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -40,7 +40,7 @@ namespace audio_transport
           _audio = gst_bin_new("audiobin");
           _convert = gst_element_factory_make("audioconvert", "convert");
           audiopad = gst_element_get_static_pad(_convert, "sink");
-          _sink = gst_element_factory_make("alsasink", "sink");
+          _sink = gst_element_factory_make("autoaudiosink", "sink");
           gst_bin_add_many( GST_BIN(_audio), _convert, _sink, NULL);
           gst_element_link(_convert, _sink);
           gst_element_add_pad(_audio, gst_ghost_pad_new("sink", audiopad));


### PR DESCRIPTION
As discussed [here](http://answers.ros.org/question/159591/debugging-audio_common-audio_play-has-poor-quality/), audio_play gives poor quality sound. I'm no gstreamer expert, not even a novice, but after playing around with some settings I found out that this worked for me.
