### PR TITLE
sound_play: Added functions to play files relative to a package path

### DIFF
--- a/sound_play/include/sound_play/sound_play.h
+++ b/sound_play/include/sound_play/sound_play.h
@@ -68,13 +68,15 @@ public:
 	private:
 		int snd_;
 		std::string arg_;
+		std::string arg2_;
 		SoundClient *client_;
 
-		Sound(SoundClient *sc, int snd, const std::string &arg)
+		Sound(SoundClient *sc, int snd, const std::string &arg, const std::string arg2 = std::string())
 		{
 			client_ = sc;
 			snd_ = snd;
 			arg_ = arg;
+			arg2_ = arg2;
 		}
 
 	public:
@@ -86,7 +88,7 @@ public:
 
 		void play()
 		{
-			client_->sendMsg(snd_, SoundRequest::PLAY_ONCE, arg_);
+			client_->sendMsg(snd_, SoundRequest::PLAY_ONCE, arg_, arg2_);
 		}
 
 		/**
@@ -98,7 +100,7 @@ public:
 
 		void repeat()
 		{
-			client_->sendMsg(snd_, SoundRequest::PLAY_START, arg_);
+			client_->sendMsg(snd_, SoundRequest::PLAY_START, arg_, arg2_);
 		}
 
 		/**
@@ -109,7 +111,7 @@ public:
 
 		void stop()
 		{
-			client_->sendMsg(snd_, SoundRequest::PLAY_STOP, arg_);
+			client_->sendMsg(snd_, SoundRequest::PLAY_STOP, arg_, arg2_);
 		}
 	};
 	
@@ -163,6 +165,21 @@ public:
   Sound waveSound(const std::string &s)
 	{
 		return Sound(this, SoundRequest::PLAY_FILE, s);
+	}
+
+/**
+ * \brief Create a wave Sound from a package.
+ *
+ * Creates a Sound corresponding to indicated file.
+ *
+ * \param p Package containing the sound file.
+ * \param s Filename of the WAV or OGG file. Must be an path relative to the package valid
+ * on the computer on which the sound_play node is running
+ */
+
+  Sound waveSoundFromPkg(const std::string &p, const std::string &s)
+	{
+		return Sound(this, SoundRequest::PLAY_FILE, s, p);
 	}
 
 /**
@@ -254,6 +271,50 @@ public:
   void stopWave(const std::string &s)
   {
     sendMsg(SoundRequest::PLAY_FILE, SoundRequest::PLAY_STOP, s);
+  }
+
+/** \brief Plays a WAV or OGG file from a package
+ *
+ * Plays a WAV or OGG file once. The playback can be stopped by stopWaveFromPkg or
+ * stopAll.
+ *
+ * \param p Package name containing the sound file.
+ * \param s Filename of the WAV or OGG file. Must be an path relative to the package valid
+ * on the computer on which the sound_play node is running
+ */
+
+  void playWaveFromPkg(const std::string &p, const std::string &s)
+  {
+    sendMsg(SoundRequest::PLAY_FILE, SoundRequest::PLAY_ONCE, s, p);
+  }
+
+/** \brief Plays a WAV or OGG file repeatedly
+ *
+ * Plays a WAV or OGG file repeatedly until stopWaveFromPkg or stopAll is used.
+ *
+ * \param p Package name containing the sound file.
+ * \param s Filename of the WAV or OGG file. Must be an path relative to the package valid
+ * on the computer on which the sound_play node is running
+ */
+
+  void startWaveFromPkg(const std::string &p, const std::string &s)
+  {
+    sendMsg(SoundRequest::PLAY_FILE, SoundRequest::PLAY_START, s, p);
+  }
+
+/** \brief Stop playing a WAV or OGG file
+ *
+ * Stops playing a file that was previously started by playWaveFromPkg or
+ * startWaveFromPkg.
+ *
+ * \param p Package name containing the sound file.
+ * \param s Filename of the WAV or OGG file. Must be an path relative to the package valid
+ * on the computer on which the sound_play node is running
+ */
+
+  void stopWaveFromPkg(const std::string &p, const std::string &s)
+  {
+    sendMsg(SoundRequest::PLAY_FILE, SoundRequest::PLAY_STOP, s, p);
   }
 
 /** \brief Play a buildin sound

--- a/sound_play/scripts/playpackage.py
+++ b/sound_play/scripts/playpackage.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+#***********************************************************
+#* Software License Agreement (BSD License)
+#*
+#*  Copyright (c) 2009, Willow Garage, Inc.
+#*  All rights reserved.
+#*
+#*  Redistribution and use in source and binary forms, with or without
+#*  modification, are permitted provided that the following conditions
+#*  are met:
+#*
+#*   * Redistributions of source code must retain the above copyright
+#*     notice, this list of conditions and the following disclaimer.
+#*   * Redistributions in binary form must reproduce the above
+#*     copyright notice, this list of conditions and the following
+#*     disclaimer in the documentation and/or other materials provided
+#*     with the distribution.
+#*   * Neither the name of the Willow Garage nor the names of its
+#*     contributors may be used to endorse or promote products derived
+#*     from this software without specific prior written permission.
+#*
+#*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+#*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+#*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+#*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+#*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+#*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#*  POSSIBILITY OF SUCH DAMAGE.
+#***********************************************************
+
+# Author: Matthias Nieuwenhuisen, Blaise Gassend
+
+
+import sys
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3 or sys.argv[1] == '--help':
+        print 'Usage: %s package sound_to_play.(ogg|wav)'%sys.argv[0]
+        print
+        print 'Plays an .OGG or .WAV file. The path to the file should be relative to the package, and be valid on the computer on which sound_play is running.'
+        exit(1)
+    
+    # Import after printing usage for speed.
+    import rospy
+    from sound_play.msg import SoundRequest
+    from sound_play.libsoundplay import SoundClient
+
+    rospy.init_node('play', anonymous = True)
+    soundhandle = SoundClient()
+    
+    rospy.sleep(1)
+    print 'Playing "%s" from pkg "%s".'%(sys.argv[2], sys.argv[1])
+    soundhandle.playWaveFromPkg(sys.argv[1], sys.argv[2])
+    rospy.sleep(1)

--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -184,18 +184,33 @@ class soundplay:
                 self.stopall()
             else:
                 if data.sound == SoundRequest.PLAY_FILE:
-                    if not data.arg in self.filesounds.keys():
-                        rospy.logdebug('command for uncached wave: "%s"'%data.arg)
-                        try:
-                            self.filesounds[data.arg] = soundtype(data.arg)
-                        except:
-                            print "Exception"
-                            rospy.logerr('Error setting up to play "%s". Does this file exist on the machine on which sound_play is running?'%data.arg)
-                            return
+                    if not data.arg2:
+                        if not data.arg in self.filesounds.keys():
+                            rospy.logdebug('command for uncached wave: "%s"'%data.arg)
+                            try:
+                                self.filesounds[data.arg] = soundtype(data.arg)
+                            except:
+                                print "Exception"
+                                rospy.logerr('Error setting up to play "%s". Does this file exist on the machine on which sound_play is running?'%data.arg)
+                                return
+                        else:
+                            print "cached"
+                            rospy.logdebug('command for cached wave: "%s"'%data.arg)
+                        sound = self.filesounds[data.arg]
                     else:
-                        print "cached"
-                        rospy.logdebug('command for cached wave: "%s"'%data.arg)
-                    sound = self.filesounds[data.arg]
+                        absfilename = os.path.join(roslib.packages.get_pkg_dir(data.arg2), data.arg)
+                        if not absfilename in self.filesounds.keys():
+                            rospy.logdebug('command for uncached wave: "%s"'%absfilename)
+                            try:
+                                self.filesounds[absfilename] = soundtype(absfilename)
+                            except:
+                                print "Exception"
+                                rospy.logerr('Error setting up to play "%s" from package "%s". Does this file exist on the machine on which sound_play is running?'%(data.arg, data.arg2))
+                                return
+                        else:
+                            print "cached"
+                            rospy.logdebug('command for cached wave: "%s"'%absfilename)
+                        sound = self.filesounds[absfilename]
                 elif data.sound == SoundRequest.SAY:
                     if not data.arg in self.voicesounds.keys():
                         rospy.logdebug('command for uncached text: "%s"' % data.arg)

--- a/sound_play/src/sound_play/libsoundplay.py
+++ b/sound_play/src/sound_play/libsoundplay.py
@@ -187,6 +187,41 @@ class SoundClient:
           sound = rootdir + "/" + sound
         self.sendMsg(SoundRequest.PLAY_FILE, SoundRequest.PLAY_STOP, sound)
 
+## \brief Plays a WAV or OGG file
+## 
+## Plays a WAV or OGG file once. The playback can be stopped by stopWaveFromPkg or
+## stopAll.
+## 
+## \param package Package name containing the sound file.
+## \param sound Filename of the WAV or OGG file. Must be an path relative to the package valid
+## on the computer on which the sound_play node is running
+
+    def playWaveFromPkg(self, package, sound):
+        self.sendMsg(SoundRequest.PLAY_FILE, SoundRequest.PLAY_ONCE, sound, package)
+
+## \brief Plays a WAV or OGG file repeatedly
+## 
+## Plays a WAV or OGG file repeatedly until stopWaveFromPkg or stopAll is used.
+## 
+## \param package Package name containing the sound file.
+## \param sound Filename of the WAV or OGG file. Must be an path relative to the package valid
+## on the computer on which the sound_play node is running
+
+    def startWaveFromPkg(self, package, sound):
+        self.sendMsg(SoundRequest.PLAY_FILE, SoundRequest.PLAY_START, sound, package)
+
+##  \brief Stop playing a WAV or OGG file
+## 
+## Stops playing a file that was previously started by playWaveFromPkg or
+## startWaveFromPkg.
+## 
+## \param package Package name containing the sound file.
+## \param sound Filename of the WAV or OGG file. Must be an path relative to the package valid
+## on the computer on which the sound_play node is running
+
+    def stopWaveFromPkg(self,sound, package):
+        self.sendMsg(SoundRequest.PLAY_FILE, SoundRequest.PLAY_STOP, sound, package)
+
 ## \brief Play a buildin sound
 ##
 ## Starts playing one of the built-in sounds. built-ing sounds are documented

--- a/sound_play/test/test.cpp
+++ b/sound_play/test/test.cpp
@@ -32,7 +32,6 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-
 #include <sound_play/sound_play.h>
 #include <unistd.h>
 
@@ -93,5 +92,11 @@ int main(int argc, char **argv)
 		s3.play();
 		sleepok(1, nh);
 		s3.stop();
+
+		sleepok(2, nh);
+		sound_play::Sound s4 = sc.waveSoundFromPkg("sound_play", "sounds/BACKINGUP.ogg");
+		s4.play();
+		sleepok(1, nh);
+		s4.stop();
   }
 }


### PR DESCRIPTION
I have added a new command PLAY_FILE_FROM_PKG that allows to play wave files relative to a package path (e.g. playWaveFromPkg("sound_play","sounds/BACKINGUP.ogg") will play the sound $SOME_PATH/sound_play/sounds/BACKINGUP.ogg). So no knowledge about the absolute path to the file is necessary. The relative path is given as arg and the package name as arg2.
