### PR TITLE
Fix for audio_play to continue playing and port to gstreamer 1.0

### DIFF
--- a/audio_capture/CMakeLists.txt
+++ b/audio_capture/CMakeLists.txt
@@ -5,16 +5,16 @@ project(audio_capture)
 find_package(catkin REQUIRED COMPONENTS roscpp audio_common_msgs)
 
 find_package(PkgConfig)
-pkg_check_modules(GST gstreamer-1.0 REQUIRED)
+pkg_check_modules(GST1.0 gstreamer-1.0 REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS thread)
 
-include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${GST_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${GST1.0_INCLUDE_DIRS})
 
 catkin_package()
 
 add_executable(audio_capture src/audio_capture.cpp)
-target_link_libraries(audio_capture ${catkin_LIBRARIES} ${GST_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(audio_capture ${catkin_LIBRARIES} ${GST1.0_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(audio_capture ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS audio_capture

--- a/audio_capture/CMakeLists.txt
+++ b/audio_capture/CMakeLists.txt
@@ -5,7 +5,7 @@ project(audio_capture)
 find_package(catkin REQUIRED COMPONENTS roscpp audio_common_msgs)
 
 find_package(PkgConfig)
-pkg_check_modules(GST gstreamer-0.10 REQUIRED)
+pkg_check_modules(GST gstreamer-1.0 REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS thread)
 

--- a/audio_capture/package.xml
+++ b/audio_capture/package.xml
@@ -17,13 +17,13 @@
 
    <build_depend>roscpp</build_depend>
    <build_depend>audio_common_msgs</build_depend>
-   <build_depend>libgstreamer0.10-dev</build_depend>
-   <build_depend>libgstreamer-plugins-base0.10-dev</build_depend>
+   <build_depend>libgstreamer1.0-dev</build_depend>
+   <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
 
    <run_depend>roscpp</run_depend>
    <run_depend>audio_common_msgs</run_depend>
-   <run_depend>libgstreamer0.10-0</run_depend>
-   <run_depend>libgstreamer-plugins-base0.10-0</run_depend>
-   <run_depend>gstreamer0.10-plugins-ugly</run_depend>
-   <run_depend>gstreamer0.10-plugins-good</run_depend>
+   <run_depend>libgstreamer1.0-0</run_depend>
+   <run_depend>libgstreamer-plugins-base1.0-0</run_depend>
+   <run_depend>gstreamer1.0-plugins-ugly</run_depend>
+   <run_depend>gstreamer1.0-plugins-good</run_depend>
 </package>

--- a/audio_play/CMakeLists.txt
+++ b/audio_play/CMakeLists.txt
@@ -5,7 +5,7 @@ project(audio_play)
 find_package(catkin REQUIRED COMPONENTS roscpp audio_common_msgs)
 
 find_package(PkgConfig)
-pkg_check_modules(GST gstreamer-0.10 REQUIRED)
+pkg_check_modules(GST gstreamer-1.0 REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS thread)
 

--- a/audio_play/CMakeLists.txt
+++ b/audio_play/CMakeLists.txt
@@ -5,16 +5,16 @@ project(audio_play)
 find_package(catkin REQUIRED COMPONENTS roscpp audio_common_msgs)
 
 find_package(PkgConfig)
-pkg_check_modules(GST gstreamer-1.0 REQUIRED)
+pkg_check_modules(GST1.0 gstreamer-1.0 REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS thread)
 
-include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${GST_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${GST1.0_INCLUDE_DIRS})
 
 catkin_package()
 
 add_executable(audio_play src/audio_play.cpp)
-target_link_libraries(audio_play ${catkin_LIBRARIES} ${GST_LIBRARIES} ${Boost_LIBRARIES}) 
+target_link_libraries(audio_play ${catkin_LIBRARIES} ${GST1.0_LIBRARIES} ${Boost_LIBRARIES}) 
 add_dependencies(audio_play ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS audio_play 

--- a/audio_play/package.xml
+++ b/audio_play/package.xml
@@ -15,15 +15,15 @@
 
    <build_depend>roscpp</build_depend>
    <build_depend>audio_common_msgs</build_depend>
-   <build_depend>libgstreamer0.10-dev</build_depend>
-   <build_depend>libgstreamer-plugins-base0.10-dev</build_depend>
+   <build_depend>libgstreamer1.0-dev</build_depend>
+   <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
 
    <run_depend>roscpp</run_depend>
    <run_depend>audio_common_msgs</run_depend>
-   <run_depend>libgstreamer0.10-0</run_depend>
-   <run_depend>libgstreamer-plugins-base0.10-0</run_depend>
-   <run_depend>gstreamer0.10-plugins-ugly</run_depend>
-   <run_depend>gstreamer0.10-plugins-good</run_depend>
+   <run_depend>libgstreamer1.0-0</run_depend>
+   <run_depend>libgstreamer-plugins-base1.0-0</run_depend>
+   <run_depend>gstreamer1.0-plugins-ugly</run_depend>
+   <run_depend>gstreamer1.0-plugins-good</run_depend>
 
 </package>
 

--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -27,6 +27,8 @@ namespace audio_transport
         _source = gst_element_factory_make("appsrc", "app_source");
         gst_bin_add( GST_BIN(_pipeline), _source);
 
+        g_signal_connect(_source, "need-data", G_CALLBACK(cb_need_data),this);
+
         //_playbin = gst_element_factory_make("playbin2", "uri_play");
         //g_object_set( G_OBJECT(_playbin), "uri", "file:///home/test/test.mp3", NULL);
         if (dst_type == "alsasink")
@@ -60,12 +62,20 @@ namespace audio_transport
         //gst_element_set_state(GST_ELEMENT(_playbin), GST_STATE_PLAYING);
 
         _gst_thread = boost::thread( boost::bind(g_main_loop_run, _loop) );
+
+        _paused = false;
       }
 
     private:
 
       void onAudio(const audio_common_msgs::AudioDataConstPtr &msg)
       {
+        if(_paused)
+        {
+          gst_element_set_state(GST_ELEMENT(_pipeline), GST_STATE_PLAYING);
+          _paused = false;
+        }
+
         GstBuffer *buffer = gst_buffer_new_and_alloc(msg->data.size());
         gst_buffer_fill(buffer, 0, &msg->data[0], msg->data.size());
         GstFlowReturn ret;
@@ -107,6 +117,16 @@ namespace audio_transport
         g_object_unref (audiopad);
       }
 
+     static void cb_need_data (GstElement *appsrc,
+                   guint       unused_size,
+                   gpointer    user_data)
+     {
+       ROS_DEBUG("need-data signal emitted! Pausing the pipeline");
+       RosGstPlay *client = reinterpret_cast<RosGstPlay*>(user_data);
+       gst_element_set_state(GST_ELEMENT(client->_pipeline), GST_STATE_PAUSED);
+       client->_paused = true;
+     }
+
       ros::NodeHandle _nh;
       ros::Subscriber _sub;
       boost::thread _gst_thread;
@@ -114,6 +134,8 @@ namespace audio_transport
       GstElement *_pipeline, *_source, *_sink, *_decoder, *_convert, *_audio;
       GstElement *_playbin;
       GMainLoop *_loop;
+
+      bool _paused;
   };
 }
 

--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -121,7 +121,7 @@ namespace audio_transport
                    guint       unused_size,
                    gpointer    user_data)
      {
-       ROS_DEBUG("need-data signal emitted! Pausing the pipeline");
+       ROS_WARN("need-data signal emitted! Pausing the pipeline");
        RosGstPlay *client = reinterpret_cast<RosGstPlay*>(user_data);
        gst_element_set_state(GST_ELEMENT(client->_pipeline), GST_STATE_PAUSED);
        client->_paused = true;


### PR DESCRIPTION
This fixes issue #50.
When the data stream on /audio stops the gstreamer pipeline is set to the 'pause' state. As soon as data arrives again the pipeline is set back to 'playing'.

As a first attempt to fix this issue I ported the audio_play and audio_capture packages to gstreamer 1.0 because 0.10 is deprecated but the issue remained.

This is the first time I put my hand on gstreamer so please correct me if I'm doing something wrong here.

Now against the master branch. 