### PR TITLE
[audio_capture] add option to publish captured audio data as wav format

### DIFF
--- a/audio_capture/launch/capture_wave.launch
+++ b/audio_capture/launch/capture_wave.launch
@@ -1,0 +1,11 @@
+<launch>
+  <!-- publish audio data as wav format -->
+  <node name="audio_capture" pkg="audio_capture" type="audio_capture"
+        output="screen">
+    <param name="format" value="wave" />
+    <param name="channels" value="1" />
+    <param name="depth" value="16" />
+    <param name="sample_rate" value="16000" />
+    <remap from="audio" to="voice_raw" />
+  </node>
+</launch>


### PR DESCRIPTION
Currenly `audio_capture` node publishes only mp3 which need to be decode to use.
I added the option to publish captured audio data as wav format.
Also added sample launch file.