### PR TITLE
[audio_capture] add option to publish captured audio data as wav format

### DIFF
--- a/audio_capture/launch/capture_wave.launch
+++ b/audio_capture/launch/capture_wave.launch
@@ -1,0 +1,9 @@
+<launch>
+  <!-- publish audio data as wav format -->
+  <node name="audio_capture" pkg="audio_capture" type="audio_capture" output="screen">
+    <param name="format" value="wave" />
+    <param name="channels" value="1" />
+    <param name="depth" value="16" />
+    <param name="sample_rate" value="16000" />
+  </node>
+</launch>

--- a/audio_capture/src/audio_capture.cpp
+++ b/audio_capture/src/audio_capture.cpp
@@ -18,8 +18,16 @@ namespace audio_transport
 
         std::string dst_type;
 
+        // Need to encoding or publish raw wave data
+        ros::param::param<std::string>("~format", _format, "mp3");
+
         // The bitrate at which to encode the audio
         ros::param::param<int>("~bitrate", _bitrate, 192);
+
+        // only available for raw data
+        ros::param::param<int>("~channels", _channels, 1);
+        ros::param::param<int>("~depth", _depth, 16);
+        ros::param::param<int>("~sample_rate", _sample_rate, 16000);
 
         // The destination of the audio
         ros::param::param<std::string>("~dst", dst_type, "appsink");
@@ -51,12 +59,28 @@ namespace audio_transport
         _source = gst_element_factory_make("alsasrc", "source");
         _convert = gst_element_factory_make("audioconvert", "convert");
 
-        _encode = gst_element_factory_make("lame", "encoder");
-        g_object_set( G_OBJECT(_encode), "preset", 1001, NULL);
-        g_object_set( G_OBJECT(_encode), "bitrate", _bitrate, NULL);
+        if (_format == "mp3"){
+          _encode = gst_element_factory_make("lame", "encoder");
+          g_object_set( G_OBJECT(_encode), "preset", 1001, NULL);
+          g_object_set( G_OBJECT(_encode), "bitrate", _bitrate, NULL);
 
-        gst_bin_add_many( GST_BIN(_pipeline), _source, _convert, _encode, _sink, NULL);
-        gst_element_link_many(_source, _convert, _encode, _sink, NULL);
+          gst_bin_add_many( GST_BIN(_pipeline), _source, _convert, _encode, _sink, NULL);
+          gst_element_link_many(_source, _convert, _encode, _sink, NULL);
+        } else if (_format == "wave") {
+          GstCaps *caps;
+          caps = gst_caps_new_simple("audio/x-raw-int",
+                                     "channels", G_TYPE_INT, _channels,
+                                     "width",    G_TYPE_INT, _depth,
+                                     "depth",    G_TYPE_INT, _depth,
+                                     "rate",     G_TYPE_INT, _sample_rate,
+                                     "signed",   G_TYPE_BOOLEAN, TRUE,
+                                     NULL);
+
+          g_object_set( G_OBJECT(_sink), "caps", caps, NULL);
+          gst_caps_unref(caps);
+          gst_bin_add_many( GST_BIN(_pipeline), _source, _sink, NULL);
+          gst_element_link_many( _source, _sink, NULL);
+        }
         /*}
         else
         {
@@ -104,7 +128,8 @@ namespace audio_transport
 
       GstElement *_pipeline, *_source, *_sink, *_convert, *_encode;
       GMainLoop *_loop;
-      int _bitrate;
+      int _bitrate, _channels, _depth, _sample_rate;
+      std::string _format;
   };
 }
 

--- a/audio_capture/src/audio_capture.cpp
+++ b/audio_capture/src/audio_capture.cpp
@@ -39,6 +39,11 @@ namespace audio_transport
 
         _loop = g_main_loop_new(NULL, false);
         _pipeline = gst_pipeline_new("ros_pipeline");
+        _bus = gst_pipeline_get_bus(GST_PIPELINE(_pipeline));
+        gst_bus_add_signal_watch(_bus);
+        g_signal_connect(_bus, "message::error",
+                         G_CALLBACK(onMessage), this);
+        g_object_unref(_bus);
 
         // We create the sink first, just for convenience
         if (dst_type == "appsink")
@@ -59,13 +64,15 @@ namespace audio_transport
         _source = gst_element_factory_make("alsasrc", "source");
         _convert = gst_element_factory_make("audioconvert", "convert");
 
+        gboolean link_ok;
+
         if (_format == "mp3"){
           _encode = gst_element_factory_make("lame", "encoder");
           g_object_set( G_OBJECT(_encode), "preset", 1001, NULL);
           g_object_set( G_OBJECT(_encode), "bitrate", _bitrate, NULL);
 
           gst_bin_add_many( GST_BIN(_pipeline), _source, _convert, _encode, _sink, NULL);
-          gst_element_link_many(_source, _convert, _encode, _sink, NULL);
+          link_ok = gst_element_link_many(_source, _convert, _encode, _sink, NULL);
         } else if (_format == "wave") {
           GstCaps *caps;
           caps = gst_caps_new_simple("audio/x-raw-int",
@@ -79,7 +86,10 @@ namespace audio_transport
           g_object_set( G_OBJECT(_sink), "caps", caps, NULL);
           gst_caps_unref(caps);
           gst_bin_add_many( GST_BIN(_pipeline), _source, _sink, NULL);
-          gst_element_link_many( _source, _sink, NULL);
+          link_ok = gst_element_link_many( _source, _sink, NULL);
+        } else {
+          ROS_ERROR_STREAM("format must be \"wave\" or \"mp3\"");
+          exitOnMainThread(1);
         }
         /*}
         else
@@ -93,9 +103,27 @@ namespace audio_transport
         }
         */
 
+        if (!link_ok) {
+          ROS_ERROR_STREAM("Unsupported media type.");
+          exitOnMainThread(1);
+        }
+
         gst_element_set_state(GST_ELEMENT(_pipeline), GST_STATE_PLAYING);
 
         _gst_thread = boost::thread( boost::bind(g_main_loop_run, _loop) );
+      }
+
+      ~RosGstCapture()
+      {
+        g_main_loop_quit(_loop);
+        gst_element_set_state(_pipeline, GST_STATE_NULL);
+        gst_object_unref(_pipeline);
+        g_main_loop_unref(_loop);
+      }
+
+      void exitOnMainThread(int code)
+      {
+        exit(code);
       }
 
       void publish( const audio_common_msgs::AudioData &msg )
@@ -116,8 +144,22 @@ namespace audio_transport
 
         server->publish(msg);
 
-        gst_buffer_unref(buffer);
         return GST_FLOW_OK;
+      }
+
+      static gboolean onMessage (GstBus *bus, GstMessage *message, gpointer userData)
+      {
+        RosGstCapture *server = reinterpret_cast<RosGstCapture*>(userData);
+        GError *err;
+        gchar *debug;
+
+        gst_message_parse_error(message, &err, &debug);
+        ROS_ERROR_STREAM("gstreamer: " << err->message);
+        g_error_free(err);
+        g_free(debug);
+        g_main_loop_quit(server->_loop);
+        server->exitOnMainThread(1);
+        return FALSE;
       }
 
     private:
@@ -127,8 +169,9 @@ namespace audio_transport
       boost::thread _gst_thread;
 
       GstElement *_pipeline, *_source, *_sink, *_convert, *_encode;
-      GMainLoop *_loop;
+      GstBus *_bus;
       int _bitrate, _channels, _depth, _sample_rate;
+      GMainLoop *_loop;
       std::string _format;
   };
 }


### PR DESCRIPTION
- [audio_capture] add option to publish captured audio data as wav format

Currenly audio_capture node publishes only mp3 which need to be decode to use.
I added the option to publish captured audio data as wav format.
Also added sample launch file.

This PR is almost copied from https://github.com/ros-drivers/audio_common/pull/60 just to send another branch