### PR TITLE
Adds capability for blocking calls to SoundClient's play.

### DIFF
--- a/sound_play/scripts/say.py
+++ b/sound_play/scripts/say.py
@@ -53,10 +53,10 @@ if __name__ == '__main__':
     import rospy
     from sound_play.msg import SoundRequest
     from sound_play.libsoundplay import SoundClient
-    
+
     if len(sys.argv) == 1:
         print 'Awaiting something to say on standard input.'
-        
+
     # Ordered this way to minimize wait time.
     rospy.init_node('say', anonymous = True)
     soundhandle = SoundClient()
@@ -64,7 +64,7 @@ if __name__ == '__main__':
 
     voice = 'voice_kal_diphone'
     volume = 1.0
-    
+
     if len(sys.argv) == 1:
         s = sys.stdin.read()
     else:
@@ -74,10 +74,10 @@ if __name__ == '__main__':
             voice = sys.argv[2]
         if len(sys.argv) > 3:
             volume = float(sys.argv[3])
-    
+
     print 'Saying: %s' % s
     print 'Voice: %s' % voice
     print 'Volume: %s' % volume
-    
+
     soundhandle.say(s, voice, volume)
     rospy.sleep(1)

--- a/sound_play/scripts/soundclient_example.py
+++ b/sound_play/scripts/soundclient_example.py
@@ -15,6 +15,7 @@ def play_blocking():
     Play various sounds, blocking until each is completed before going to the
     next.
     """
+    rospy.loginfo('Playing sounds in *blocking* mode.')
     soundhandle = SoundClient(blocking=True)
 
     rospy.loginfo('Playing say-beep at full volume.')
@@ -34,7 +35,7 @@ def play_nonblocking():
     """
     Play the same sounds with manual pauses between them.
     """
-
+    rospy.loginfo('Playing sounds in *non-blocking* mode.')
     # NOTE: you must sleep at the beginning to let the SoundClient publisher
     # establish a connection to the soundplay_node.
     soundhandle = SoundClient(blocking=False)
@@ -60,5 +61,5 @@ def play_nonblocking():
 
 if __name__ == '__main__':
     rospy.init_node('soundclient_example', anonymous=False)
-    # play_blocking()
+    play_blocking()
     play_nonblocking()

--- a/sound_play/scripts/soundclient_example.py
+++ b/sound_play/scripts/soundclient_example.py
@@ -2,7 +2,7 @@
 
 """
 Simple example showing how to use the SoundClient provided by libsoundplay,
-both in blocking and non-blocking usage.
+in blocking, non-blocking, and explicit usage.
 """
 
 import rospy
@@ -10,12 +10,36 @@ from sound_play.libsoundplay import SoundClient
 from sound_play.msg import SoundRequest
 
 
+def play_explicit():
+    rospy.loginfo('Example: SoundClient play methods can take in an explicit'
+                  ' blocking parameter')
+    soundhandle = SoundClient()  # blocking = False by default
+    rospy.sleep(0.5)  # Ensure publisher connection is successful.
+
+    sound_beep = soundhandle.waveSound("say-beep.wav", volume=0.5)
+    # Play the same sound twice, once blocking and once not. The first call is
+    # blocking (explicitly specified).
+    sound_beep.play(blocking=True)
+    # This call is not blocking (uses the SoundClient's setting).
+    sound_beep.play()
+    rospy.sleep(0.5)  # Let sound complete.
+
+    # Play a blocking sound.
+    soundhandle.play(SoundRequest.NEEDS_UNPLUGGING, blocking=True)
+
+    # Create a new SoundClient where the default behavior *is* to block.
+    soundhandle = SoundClient(blocking=True)
+    soundhandle.say('Say-ing stuff while block-ing')
+    soundhandle.say('Say-ing stuff without block-ing', blocking=False)
+    rospy.sleep(1)
+
+
 def play_blocking():
     """
     Play various sounds, blocking until each is completed before going to the
     next.
     """
-    rospy.loginfo('Playing sounds in *blocking* mode.')
+    rospy.loginfo('Example: Playing sounds in *blocking* mode.')
     soundhandle = SoundClient(blocking=True)
 
     rospy.loginfo('Playing say-beep at full volume.')
@@ -35,7 +59,7 @@ def play_nonblocking():
     """
     Play the same sounds with manual pauses between them.
     """
-    rospy.loginfo('Playing sounds in *non-blocking* mode.')
+    rospy.loginfo('Example: Playing sounds in *non-blocking* mode.')
     # NOTE: you must sleep at the beginning to let the SoundClient publisher
     # establish a connection to the soundplay_node.
     soundhandle = SoundClient(blocking=False)
@@ -61,5 +85,7 @@ def play_nonblocking():
 
 if __name__ == '__main__':
     rospy.init_node('soundclient_example', anonymous=False)
+    play_explicit()
     play_blocking()
     play_nonblocking()
+    rospy.loginfo('Finished')

--- a/sound_play/scripts/soundclient_example.py
+++ b/sound_play/scripts/soundclient_example.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+"""
+Simple example showing how to use the SoundClient provided by libsoundplay,
+both in blocking and non-blocking usage.
+"""
+
+import rospy
+from sound_play.libsoundplay import SoundClient
+from sound_play.msg import SoundRequest
+
+
+def play_blocking():
+    """
+    Play various sounds, blocking until each is completed before going to the
+    next.
+    """
+    soundhandle = SoundClient(blocking=True)
+
+    rospy.loginfo('Playing say-beep at full volume.')
+    soundhandle.playWave('say-beep.wav')
+
+    rospy.loginfo('Playing say-beep at volume 0.3.')
+    soundhandle.playWave('say-beep.wav', volume=0.3)
+
+    rospy.loginfo('Playing sound for NEEDS_PLUGGING.')
+    soundhandle.play(SoundRequest.NEEDS_PLUGGING)
+
+    rospy.loginfo('Speaking some long string.')
+    soundhandle.say('It was the best of times, it was the worst of times.')
+
+
+def play_nonblocking():
+    """
+    Play the same sounds with manual pauses between them.
+    """
+
+    # NOTE: you must sleep at the beginning to let the SoundClient publisher
+    # establish a connection to the soundplay_node.
+    soundhandle = SoundClient(blocking=False)
+    rospy.sleep(1)
+
+    # In the non-blocking version you need to sleep between calls.
+    rospy.loginfo('Playing say-beep at full volume.')
+    soundhandle.playWave('say-beep.wav')
+    rospy.sleep(1)
+
+    rospy.loginfo('Playing say-beep at volume 0.3.')
+    soundhandle.playWave('say-beep.wav', volume=0.3)
+    rospy.sleep(1)
+
+    rospy.loginfo('Playing sound for NEEDS_PLUGGING.')
+    soundhandle.play(SoundRequest.NEEDS_PLUGGING)
+    rospy.sleep(1)
+
+    rospy.loginfo('Speaking some long string.')
+    soundhandle.say('It was the best of times, it was the worst of times.')
+    # Note we will return before the string has finished playing.
+
+
+if __name__ == '__main__':
+    rospy.init_node('soundclient_example', anonymous=False)
+    # play_blocking()
+    play_nonblocking()

--- a/sound_play/src/sound_play/libsoundplay.py
+++ b/sound_play/src/sound_play/libsoundplay.py
@@ -298,10 +298,10 @@ class SoundClient(object):
                               " soundplay_node.py?");
 
         if self.actionclient:  # Send request as an actionlib goal (blocking)
-            rospy.loginfo('Sending action client sound request [blocking]')
+            rospy.logdebug('Sending action client sound request [blocking]')
             self.actionclient.wait_for_server()
             goal = SoundRequestGoal()
             goal.sound_request = msg
             self.actionclient.send_goal(goal)
             self.actionclient.wait_for_result()
-            rospy.loginfo('sound request response received')
+            rospy.logdebug('sound request response received')

--- a/sound_play/src/sound_play/libsoundplay.py
+++ b/sound_play/src/sound_play/libsoundplay.py
@@ -284,13 +284,8 @@ class SoundClient(object):
         msg = SoundRequest()
         msg.sound = snd
 
-        if vol < 0:
-            msg.volume = 0
-        elif vol > 1.0:
-            msg.volume = 1.0
-        else:
-            msg.volume = vol
-
+        # Threshold volume between 0 and 1.
+        msg.volume = max(0, min(1, vol))
         msg.command = cmd
         msg.arg = s
         msg.arg2 = arg2

--- a/sound_play/src/sound_play/libsoundplay.py
+++ b/sound_play/src/sound_play/libsoundplay.py
@@ -58,9 +58,9 @@ class Sound:
         self.snd = snd
         self.arg = arg
         self.vol = volume
-    
+
 ## \brief Play the Sound.
-## 
+##
 ## This method causes the Sound to be played once.
 
     def play(self):
@@ -70,7 +70,7 @@ class Sound:
 ##
 ## This method causes the Sound to be played repeatedly until stop() is
 ## called.
-    
+
     def repeat(self):
        self.client.sendMsg(self.snd, SoundRequest.PLAY_START, self.arg, vol=self.vol)
 
@@ -94,7 +94,7 @@ class SoundClient:
 ## Creates a Sound corresponding to saying the indicated text.
 ##
 ## \param s Text to say
- 
+
     def voiceSound(self, s, volume=1.0):
         return Sound(self, SoundRequest.SAY, s, volume=volume)
 
@@ -109,7 +109,7 @@ class SoundClient:
           rootdir = os.path.join(roslib.packages.get_pkg_dir('sound_play'),'sounds')
           sound = rootdir + "/" + sound
         return Sound(self, SoundRequest.PLAY_FILE, sound, volume=volume)
-    
+
 ## \brief Create a builtin Sound.
 ##
 ## Creates a Sound corresponding to indicated builtin wave.
@@ -120,39 +120,39 @@ class SoundClient:
         return Sound(self, id, "", volume)
 
 ## \brief Say a string
-## 
+##
 ## Send a string to be said by the sound_node. The vocalization can be
 ## stopped using stopSaying or stopAll.
-## 
+##
 ## \param text String to say
 
     def say(self,text, voice='', volume=1.0):
         self.sendMsg(SoundRequest.SAY, SoundRequest.PLAY_ONCE, text, voice, volume)
 
 ## \brief Say a string repeatedly
-## 
+##
 ## The string is said repeatedly until stopSaying or stopAll is used.
-## 
+##
 ## \param text String to say repeatedly
 
     def repeat(self,text, volume=1.0):
         self.sendMsg(SoundRequest.SAY, SoundRequest.PLAY_START, text, vol=volume)
 
 ## \brief Stop saying a string
-## 
+##
 ## Stops saying a string that was previously started by say or repeat. The
 ## argument indicates which string to stop saying.
-## 
+##
 ## \param text Same string as in the say or repeat command
 
     def stopSaying(self,text):
         self.sendMsg(SoundRequest.SAY, SoundRequest.PLAY_STOP, text)
-    
+
 ## \brief Plays a WAV or OGG file
-## 
+##
 ## Plays a WAV or OGG file once. The playback can be stopped by stopWave or
 ## stopAll.
-## 
+##
 ## \param sound Filename of the WAV or OGG file. Must be an absolute path valid
 ## on the computer on which the sound_play node is running
 
@@ -161,11 +161,11 @@ class SoundClient:
           rootdir = os.path.join(roslib.packages.get_pkg_dir('sound_play'),'sounds')
           sound = rootdir + "/" + sound
         self.sendMsg(SoundRequest.PLAY_FILE, SoundRequest.PLAY_ONCE, sound, vol=volume)
-    
+
 ## \brief Plays a WAV or OGG file repeatedly
-## 
+##
 ## Plays a WAV or OGG file repeatedly until stopWave or stopAll is used.
-## 
+##
 ## \param sound Filename of the WAV or OGG file. Must be an absolute path valid
 ## on the computer on which the sound_play node is running.
 
@@ -176,10 +176,10 @@ class SoundClient:
         self.sendMsg(SoundRequest.PLAY_FILE, SoundRequest.PLAY_START, sound, vol=volume)
 
 ##  \brief Stop playing a WAV or OGG file
-## 
+##
 ## Stops playing a file that was previously started by playWave or
 ## startWave.
-## 
+##
 ## \param sound Same string as in the playWave or startWave command
 
     def stopWave(self,sound):
@@ -189,10 +189,10 @@ class SoundClient:
         self.sendMsg(SoundRequest.PLAY_FILE, SoundRequest.PLAY_STOP, sound)
 
 ## \brief Plays a WAV or OGG file
-## 
+##
 ## Plays a WAV or OGG file once. The playback can be stopped by stopWaveFromPkg or
 ## stopAll.
-## 
+##
 ## \param package Package name containing the sound file.
 ## \param sound Filename of the WAV or OGG file. Must be an path relative to the package valid
 ## on the computer on which the sound_play node is running
@@ -201,9 +201,9 @@ class SoundClient:
         self.sendMsg(SoundRequest.PLAY_FILE, SoundRequest.PLAY_ONCE, sound, package, volume)
 
 ## \brief Plays a WAV or OGG file repeatedly
-## 
+##
 ## Plays a WAV or OGG file repeatedly until stopWaveFromPkg or stopAll is used.
-## 
+##
 ## \param package Package name containing the sound file.
 ## \param sound Filename of the WAV or OGG file. Must be an path relative to the package valid
 ## on the computer on which the sound_play node is running
@@ -212,10 +212,10 @@ class SoundClient:
         self.sendMsg(SoundRequest.PLAY_FILE, SoundRequest.PLAY_START, sound, package, volume)
 
 ##  \brief Stop playing a WAV or OGG file
-## 
+##
 ## Stops playing a file that was previously started by playWaveFromPkg or
 ## startWaveFromPkg.
-## 
+##
 ## \param package Package name containing the sound file.
 ## \param sound Filename of the WAV or OGG file. Must be an path relative to the package valid
 ## on the computer on which the sound_play node is running
@@ -239,40 +239,40 @@ class SoundClient:
 ## stopall is used. Built-in sounds are documented in \ref SoundRequest.msg.
 ##
 ## \param sound Identifier of the sound to play.
-    
+
     def start(self,sound, volume=1.0):
         self.sendMsg(sound, SoundRequest.PLAY_START, "", vol=volume)
 
 ## \brief Stop playing a built-in sound
 ##
-## Stops playing a built-in sound started with play or start. 
+## Stops playing a built-in sound started with play or start.
 ##
 ## \param sound Same sound that was used to start playback
-    
+
     def stop(self,sound):
         self.sendMsg(sound, SoundRequest.PLAY_STOP, "")
 
 ## \brief Stop all currently playing sounds
 ##
 ## This method stops all speech, wave file, and built-in sound playback.
-  
+
     def stopAll(self):
         self.stop(SoundRequest.ALL)
 
     def sendMsg(self, snd, cmd, s, arg2="", vol=1.0):
         msg = SoundRequest()
         msg.sound = snd
-        
+
         if vol < 0:
             msg.volume = 0
         elif vol > 1.0:
             msg.volume = 1.0
         else:
             msg.volume = vol
-        
+
         msg.command = cmd
         msg.arg = s
-        msg.arg2 = arg2 
+        msg.arg2 = arg2
         self.pub.publish(msg)
 
         if self.pub.get_num_connections() < 1:

--- a/sound_play/src/sound_play/libsoundplay.py
+++ b/sound_play/src/sound_play/libsoundplay.py
@@ -38,8 +38,11 @@
 
 import rospy
 import roslib
+import actionlib
 import os, sys
 from sound_play.msg import SoundRequest
+from sound_play.msg import SoundRequestGoal
+from sound_play.msg import SoundRequestAction
 
 ## \brief Class that publishes messages to the sound_play node.
 ##
@@ -86,8 +89,22 @@ class Sound(object):
 ## between methods and invocations of the \ref sound_play.SoundRequest message.
 
 class SoundClient(object):
-    def __init__(self):
-        self.pub = rospy.Publisher('robotsound', SoundRequest, queue_size=5)
+
+    def __init__(self, blocking=False):
+        # If blocking is false, the sound request is published directly to the
+        # soundplay_node and the methods return immediately. Otherwise, the
+        # SoundClient uses the actionlib interface (also provided by
+        # soundplay_node) to wait until the sound has finished playing
+        # completely before returning.
+
+        # NOTE: only one of these will be used at once.
+        self.pub = None
+        self.actionclient = None
+
+        if blocking:
+            self.actionclient = actionlib.SimpleActionClient('sound_play', SoundRequestAction)
+        else:
+            self.pub = rospy.Publisher('robotsound', SoundRequest, queue_size=5)
 
 ## \brief Create a voice Sound.
 ##
@@ -260,6 +277,10 @@ class SoundClient(object):
         self.stop(SoundRequest.ALL)
 
     def sendMsg(self, snd, cmd, s, arg2="", vol=1.0):
+        # Internal method that publishes the sound request, either directly as a
+        # SoundRequest to the soundplay_node or through the actionlib interface
+        # (which blocks until the sound has finished playing).
+
         msg = SoundRequest()
         msg.sound = snd
 
@@ -273,7 +294,19 @@ class SoundClient(object):
         msg.command = cmd
         msg.arg = s
         msg.arg2 = arg2
-        self.pub.publish(msg)
 
-        if self.pub.get_num_connections() < 1:
-            rospy.logwarn("Sound command issued, but no node is subscribed to the topic. Perhaps you forgot to run soundplay_node.py?");
+        if self.pub:  # Publish message directly.
+            self.pub.publish(msg)
+            if self.pub.get_num_connections() < 1:
+                rospy.logwarn("Sound command issued, but no node is subscribed"
+                              " to the topic. Perhaps you forgot to run"
+                              " soundplay_node.py?");
+
+        if self.actionclient:  # Send request as an actionlib goal (blocking)
+            rospy.loginfo('Sending action client sound request [blocking]')
+            self.actionclient.wait_for_server()
+            goal = SoundRequestGoal()
+            goal.sound_request = msg
+            self.actionclient.send_goal(goal)
+            self.actionclient.wait_for_result()
+            rospy.loginfo('sound request response received')

--- a/sound_play/src/sound_play/libsoundplay.py
+++ b/sound_play/src/sound_play/libsoundplay.py
@@ -52,7 +52,7 @@ from sound_play.msg import SoundRequest
 ## - It provides methods for each way in which the sound_play.SoundRequest
 ##   message can be invoked.
 
-class Sound:
+class Sound(object):
     def __init__(self, client, snd, arg, volume=1.0):
         self.client = client
         self.snd = snd
@@ -85,7 +85,7 @@ class Sound:
 ## via the \ref sound_play.SoundRequest message. There is a one-to-one mapping
 ## between methods and invocations of the \ref sound_play.SoundRequest message.
 
-class SoundClient:
+class SoundClient(object):
     def __init__(self):
         self.pub = rospy.Publisher('robotsound', SoundRequest, queue_size=5)
 


### PR DESCRIPTION
The SoundClient can now be asked to wait until the requested sound has finished playing before returning, by making use of @aginika 's actionlib implementation. This removes the need for manual sleeping after a sound request is published. The default (out-of-the-box) behavior is unchanged (SoundClient returns immediately) so this should be transparent to everyone.

I also added an example (`soundclient_example.py`) that shows how to use the SoundClient in both blocking and non-blocking modes.

Lastly I snuck in some linting (trailing whitespace, new-style python classes), let me know if you object.