### PR TITLE
sound_client actionlib dependency fix

### DIFF
--- a/sound_play/CMakeLists.txt
+++ b/sound_play/CMakeLists.txt
@@ -16,6 +16,8 @@ generate_messages(DEPENDENCIES actionlib_msgs)
 catkin_package(CATKIN_DEPENDS message_runtime actionlib_msgs
                INCLUDE_DIRS include)
 
+catkin_add_nosetests(scripts/test)
+
 add_subdirectory(test)
 
 install(PROGRAMS

--- a/sound_play/package.xml
+++ b/sound_play/package.xml
@@ -16,6 +16,7 @@
    <build_depend>roscpp</build_depend>
    <build_depend>roslib</build_depend>
    <build_depend>actionlib_msgs</build_depend>
+   <build_depend>actionlib</build_depend>
    <build_depend>audio_common_msgs</build_depend>
    <build_depend>diagnostic_msgs</build_depend>
    <build_depend>libgstreamer0.10-dev</build_depend>
@@ -40,5 +41,3 @@
       <cpp cflags="-I${prefix}/include -I${prefix}/msg/cpp" />
    </export>
 </package>
-
-

--- a/sound_play/scripts/test/test_sound_client.py
+++ b/sound_play/scripts/test/test_sound_client.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import unittest
+
+import rospy
+import rostest
+from sound_play.libsoundplay import SoundClient
+
+class TestCase(unittest.TestCase):
+    def test_soundclient_constructor(self):
+        s = SoundClient()
+        self.assertIsNotNone(s)
+
+if __name__ == '__main__':
+    rostest.rosrun('sound_play', 'test_sound_client', TestCase)
+
+__author__ = 'Felix Duvallet'


### PR DESCRIPTION
This PR demonstrates an instance of the missing dependency on actionlib ( #66 ).

It adds a unit test that just creates a SoundClient object. This test fails when running on a clean machine with all rosdep dependencies resolved, for example on Travis continuous integration [here](https://travis-ci.org/felixduvallet/audio_common/builds/92227443).

It also [fixes](https://travis-ci.org/felixduvallet/audio_common/builds/92228025) the problem by specifying the actionlib dependency in package.xml, so it should fix the issue.