### PR TITLE
[soundplay_node] fix resources not being released on dict cleanup

### DIFF
--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -292,6 +292,7 @@ class soundplay:
                 self.active_sounds = self.active_sounds + 1
         for key in purgelist:
            rospy.logdebug('Purging %s from cache'%key)
+           dict[key].stop() # clean up resources
            del dict[key]
 
     def cleanup(self):


### PR DESCRIPTION
This was resulting in the number of sink inputs reaching the maximum threshold,
(32 on ubuntu 14.04 with pulseaudio 4.0) after which no more sounds could be
played by the node. It would only happen if the rate of sounds being played was
slower than the dictionary cleanup.

Some files which can help illustrate the problem:

`sound_play/launch/sound_test.launch`
```
<launch>
  <node pkg="sound_play" type="soundplay_node.py" name="soundplay_node"/>
  <node pkg="sound_play" type="sound_test" name="sound_test"/>
</launch>

```

`sound_play/scripts/sound_test`
```
#!/usr/bin/env python

import os
import roslib
import rospy
from std_msgs.msg import Empty
from sound_play.libsoundplay import SoundClient

class SoundPlayer:
    def sound_callback(self, msg):
        self.sound_client.playWave(self.sound_file, 0.1)

    def __init__(self):
        rospy.init_node('sound_player')
        rospy.sleep(1) # need to wait for sound client to init
        self.sound_file = os.path.join(roslib.packages.get_pkg_dir('sound_play'),'sounds/BACKINGUP.ogg')
        self.sound_client = SoundClient()

	rospy.Subscriber('~play_sound', Empty, self.sound_callback)
        
        rospy.spin()

if __name__ == '__main__':
    player = SoundPlayer()
```

Run `roslaunch sound_play sound_test.launch --screen` and `rostopic pub /sound_test/play_sound std_msgs/Empty "{}" -r 0.09` without the update in this PR. Wait approximately 6 minutes. In this time, you might want to look at the output of `pactl list short sink-inputs`. As each sound is played, you should notice the number of sink inputs increasing. It will increase to 32 (tested on ubuntu 14.04 with pulseaudio 4.0), at which point you will see something like the following error in `/var/log/syslog`

```
pulseaudio[3037]: [pulseaudio] sink-input.c: Failed to create sink input: too many inputs per sink
```

After this point, sounds from the sound node will no longer play.