### PR TITLE
There's an error in testing for missign Publisher/action client in sendMsg

### DIFF
--- a/sound_play/src/sound_play/libsoundplay.py
+++ b/sound_play/src/sound_play/libsoundplay.py
@@ -320,10 +320,10 @@ class SoundClient(object):
                        ' and blocking = {}'.format(msg.volume, blocking))
 
         # Defensive check for the existence of the correct communicator.
-        if blocking and not self.pub:
+        if not blocking and not self.pub:
             rospy.logerr('Publisher for SoundRequest must exist')
             return
-        if not blocking and not self.actionclient:
+        if blocking and not self.actionclient:
             rospy.logerr('Action client for SoundRequest does not exist.')
             return
 


### PR DESCRIPTION
The tested conditions in sendMsg (in libsoundplay.py) are inverted, and the publisher is only checked for the blocking case, and the action client is only checked for the non-blocking case.
This leads to confusing error logs and situations.