### PR TITLE
[sound_play/scripts/soundplay_node.py] updates states and force stop after play

### DIFF
--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -99,7 +99,7 @@ class soundtype:
 
     def on_stream_end(self, bus, message):
         if message.type == gst.MESSAGE_EOS:
-            self.state = self.STOPPED
+            self.stop()
 
     def __del__(self):
         # stop our GST object so that it gets garbage-collected
@@ -187,6 +187,14 @@ class soundplay:
         self.stopdict(self.builtinsounds)
         self.stopdict(self.filesounds)
         self.stopdict(self.voicesounds)
+
+    def update(self):
+        for sound in self.builtinsounds.values():
+            sound.update()
+        for sound in self.filesounds.values():
+            sound.update()
+        for sound in self.voicesounds.values():
+            sound.update()
 
     def select_sound(self, data):
         if data.sound == SoundRequest.PLAY_FILE:
@@ -437,6 +445,7 @@ class soundplay:
             #print "idle_loop"
             self.diagnostics(0)
             self.sleep(1)
+            self.update()
             self.cleanup()
         #print "idle_exiting"
 


### PR DESCRIPTION
This pull request is minimum fix of bug reported at https://github.com/ros-drivers/audio_common/issues/75 from https://github.com/ros-drivers/audio_common/pull/77.
(Still other bugs are left without fix)
- bugfix: 'too many files open' (reported at #75 )
  
  This bug occurs because `soundplay_node` holds file descriptor of all playing wave files even after finished playing.
