### PR TITLE
Provide alsasrc device as parameter

### DIFF
--- a/audio_capture/launch/capture.launch
+++ b/audio_capture/launch/capture.launch
@@ -5,12 +5,15 @@
   <arg name="device" default=""/>
   <arg name="channels" default="1"/>
   <arg name="sample_rate" default="16000"/>
-  
+  <arg name="ns" default="audio"/>
+
+  <group ns="$(arg ns)">
   <node name="audio_capture" pkg="audio_capture" type="audio_capture" output="screen">
     <param name="bitrate" value="128"/>
     <param name="device" value="$(arg device)"/>
     <param name="channels" value="$(arg channels)"/>
     <param name="sample_rate" value="$(arg sample_rate)"/>
   </node>
+  </group>
 
 </launch>

--- a/audio_capture/launch/capture.launch
+++ b/audio_capture/launch/capture.launch
@@ -1,7 +1,16 @@
 <launch>
-
+  <!-- arecord -l will show available input devices, use the car number as
+      the first number and the subdevice number as the second in a string
+      like hw:1,0 -->
+  <arg name="device" default=""/>
+  <arg name="channels" default="1"/>
+  <arg name="sample_rate" default="16000"/>
+  
   <node name="audio_capture" pkg="audio_capture" type="audio_capture" output="screen">
     <param name="bitrate" value="128"/>
+    <param name="device" value="$(arg device)"/>
+    <param name="channels" value="$(arg channels)"/>
+    <param name="sample_rate" value="$(arg sample_rate)"/>
   </node>
 
 </launch>

--- a/audio_capture/src/audio_capture.cpp
+++ b/audio_capture/src/audio_capture.cpp
@@ -34,6 +34,8 @@ namespace audio_transport
 
         // The source of the audio
         //ros::param::param<std::string>("~src", source_type, "alsasrc");
+        std::string device;
+        ros::param::param<std::string>("~device", device, "");
 
         _pub = _nh.advertise<audio_common_msgs::AudioData>("audio", 10, true);
 
@@ -62,6 +64,29 @@ namespace audio_transport
         }
 
         _source = gst_element_factory_make("alsasrc", "source");
+        // if device isn't specified, it will use the default which is
+        // the alsa default source.
+        // A valid device will be of the foram hw:0,0 with other numbers
+        // than 0 and 0 as are available.
+        if (device != "")
+        {
+          // ghcar *gst_device = device.c_str();
+          g_object_set(G_OBJECT(_source), "device", device.c_str(), NULL);
+        }
+
+        _filter = gst_element_factory_make("capsfilter", "filter");
+        {
+          GstCaps *caps;
+          caps = gst_caps_new_simple("audio/x-raw",
+                        //      "channels", G_TYPE_INT, _channels,
+                        //      "depth",    G_TYPE_INT, _depth,
+                              "rate",     G_TYPE_INT, _sample_rate,
+                        //       "signed",   G_TYPE_BOOLEAN, TRUE,
+                              NULL);
+          g_object_set( G_OBJECT(_filter), "caps", caps, NULL);
+          gst_caps_unref(caps);
+        }
+
         _convert = gst_element_factory_make("audioconvert", "convert");
 
         gboolean link_ok;
@@ -71,8 +96,8 @@ namespace audio_transport
           g_object_set( G_OBJECT(_encode), "quality", 2.0, NULL);
           g_object_set( G_OBJECT(_encode), "bitrate", _bitrate, NULL);
 
-          gst_bin_add_many( GST_BIN(_pipeline), _source, _convert, _encode, _sink, NULL);
-          link_ok = gst_element_link_many(_source, _convert, _encode, _sink, NULL);
+          gst_bin_add_many( GST_BIN(_pipeline), _source, _filter, _convert, _encode, _sink, NULL);
+          link_ok = gst_element_link_many(_source, _filter, _convert, _encode, _sink, NULL);
         } else if (_format == "wave") {
           GstCaps *caps;
           caps = gst_caps_new_simple("audio/x-raw-int",
@@ -173,7 +198,7 @@ namespace audio_transport
 
       boost::thread _gst_thread;
 
-      GstElement *_pipeline, *_source, *_sink, *_convert, *_encode;
+      GstElement *_pipeline, *_source, *_filter, *_sink, *_convert, *_encode;
       GstBus *_bus;
       int _bitrate, _channels, _depth, _sample_rate;
       GMainLoop *_loop;

--- a/audio_play/launch/play.launch
+++ b/audio_play/launch/play.launch
@@ -1,7 +1,9 @@
 <launch>
+  <arg name="ns" default="audio"/>
 
+  <group ns="$(arg ns)">
   <node name="audio_play" pkg="audio_play" type="audio_play" output="screen">
     <param name="dst" value="alsasink"/>
   </node>
-
+  </group>
 </launch>


### PR DESCRIPTION
Allows setting of input device from multiple without having to set that device to the default input, and multiple instances of audio_capture to run simultaneously on different sources.