### PR TITLE
fix(audio_capture): capturing wave using gst1.0

### DIFF
--- a/audio_capture/src/audio_capture.cpp
+++ b/audio_capture/src/audio_capture.cpp
@@ -100,7 +100,7 @@ namespace audio_transport
           link_ok = gst_element_link_many(_source, _filter, _convert, _encode, _sink, NULL);
         } else if (_format == "wave") {
           GstCaps *caps;
-          caps = gst_caps_new_simple("audio/x-raw-int",
+          caps = gst_caps_new_simple("audio/x-raw",
                                      "channels", G_TYPE_INT, _channels,
                                      "width",    G_TYPE_INT, _depth,
                                      "depth",    G_TYPE_INT, _depth,


### PR DESCRIPTION
0.10-style raw audio caps were being created, according to GStreamer warning. Should be audio/x-raw,format=(string).. now.
fixes #92