### PR TITLE
audio_play: Fix mp3 clip overlap by never pausing the pipeline

### DIFF
--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -25,9 +25,8 @@ namespace audio_transport
 
         _pipeline = gst_pipeline_new("app_pipeline");
         _source = gst_element_factory_make("appsrc", "app_source");
+        g_object_set(G_OBJECT(_source), "do-timestamp", TRUE, NULL);
         gst_bin_add( GST_BIN(_pipeline), _source);
-
-        g_signal_connect(_source, "need-data", G_CALLBACK(cb_need_data),this);
 
         //_playbin = gst_element_factory_make("playbin2", "uri_play");
         //g_object_set( G_OBJECT(_playbin), "uri", "file:///home/test/test.mp3", NULL);
@@ -62,20 +61,12 @@ namespace audio_transport
         //gst_element_set_state(GST_ELEMENT(_playbin), GST_STATE_PLAYING);
 
         _gst_thread = boost::thread( boost::bind(g_main_loop_run, _loop) );
-
-        _paused = false;
       }
 
     private:
 
       void onAudio(const audio_common_msgs::AudioDataConstPtr &msg)
       {
-        if(_paused)
-        {
-          gst_element_set_state(GST_ELEMENT(_pipeline), GST_STATE_PLAYING);
-          _paused = false;
-        }
-
         GstBuffer *buffer = gst_buffer_new_and_alloc(msg->data.size());
         gst_buffer_fill(buffer, 0, &msg->data[0], msg->data.size());
         GstFlowReturn ret;
@@ -117,16 +108,6 @@ namespace audio_transport
         g_object_unref (audiopad);
       }
 
-     static void cb_need_data (GstElement *appsrc,
-                   guint       unused_size,
-                   gpointer    user_data)
-     {
-       ROS_WARN("need-data signal emitted! Pausing the pipeline");
-       RosGstPlay *client = reinterpret_cast<RosGstPlay*>(user_data);
-       gst_element_set_state(GST_ELEMENT(client->_pipeline), GST_STATE_PAUSED);
-       client->_paused = true;
-     }
-
       ros::NodeHandle _nh;
       ros::Subscriber _sub;
       boost::thread _gst_thread;
@@ -134,8 +115,6 @@ namespace audio_transport
       GstElement *_pipeline, *_source, *_sink, *_decoder, *_convert, *_audio;
       GstElement *_playbin;
       GMainLoop *_loop;
-
-      bool _paused;
   };
 }
 


### PR DESCRIPTION
We were seeing an issue when publishing mp3 clips.  The tail end of each clip was cut off and applied to the beginning of the next clip with varying intensity (but a short clip was almost always lost entirely).

It looked like the `need-data` event was causing a pipeline pause before the rest of the pipeline was drained.  Manually draining the pipeline seemed like a real chore, so I removed the pipeline pausing feature and set a property on the source allowing for the kind of ad hoc input we intend to feed it.