### PR TITLE
use default audio output by default

### DIFF
--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -395,7 +395,7 @@ class soundplay:
     def __init__(self):
         Gst.init(None)
         rospy.init_node('sound_play')
-        self.device = rospy.get_param("~device", str())
+        self.device = rospy.get_param("~device", "default")
         self.diagnostic_pub = rospy.Publisher("/diagnostics", DiagnosticArray, queue_size=1)
         rootdir = os.path.join(roslib.packages.get_pkg_dir('sound_play'),'sounds')
 


### PR DESCRIPTION
Not specifying a sound device defaults to *the first* sound device starting from Ubuntu 16.04., not to the one configured as default.

The change is backward compatible and tested on ROS indigo and kinetic on a PR2 robot.