### PR TITLE
Do not encode text when using langages which ISO-8859-15 does not support

### DIFF
--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -236,7 +236,10 @@ class soundplay:
                 os.close(wavfile)
                 voice = data.arg2
                 try:
-                    txtfile.write(data.arg.decode('UTF-8').encode('ISO-8859-15'))
+                    try:
+                        txtfile.write(data.arg.decode('UTF-8').encode('ISO-8859-15'))
+                    except UnicodeEncodeError:
+                        txtfile.write(data.arg)
                     txtfile.flush()
                     os.system("text2wave -eval '("+voice+")' "+txtfilename+" -o "+wavfilename)
                     try:


### PR DESCRIPTION
When robots try to speak japanese texts, they cannot encode the texts into `ISO-8859-15`.

For example, 
English OK:
```
In [1]: 'a'.decode('UTF-8').encode('ISO-8859-15')
Out[1]: 'a'
```
Japanese NG:
```
In [2]: 'あ'.decode('UTF-8').encode('ISO-8859-15')
---------------------------------------------------------------------------
UnicodeEncodeError                        Traceback (most recent call last)
<ipython-input-2-aa06742ae966> in <module>()
----> 1 'あ'.decode('UTF-8').encode('ISO-8859-15')

/usr/lib/python2.7/encodings/iso8859_15.py in encode(self, input, errors)
     10 
     11     def encode(self,input,errors='strict'):
---> 12         return codecs.charmap_encode(input,errors,encoding_table)
     13 
     14     def decode(self,input,errors='strict'):

UnicodeEncodeError: 'charmap' codec can't encode character u'\u3042' in position 0: character maps to <undefined>
```

Therefore, I introduce try-except block to catch the error.
Cc @itohdak