### PR TITLE
[audio_play] support wave format 

### DIFF
--- a/audio_play/launch/play.launch
+++ b/audio_play/launch/play.launch
@@ -2,11 +2,13 @@
   <arg name="ns" default="audio"/>
   <arg name="dst" default="alsasink"/>
   <arg name="do_timestamp" default="true"/>
+  <arg name="format" default="mp3"/>
 
   <group ns="$(arg ns)">
   <node name="audio_play" pkg="audio_play" type="audio_play" output="screen">
     <param name="dst" value="$(arg dst)"/>
     <param name="do_timestamp" value="$(arg do_timestamp)"/>
+    <param name="format" value="$(arg format)"/>
   </node>
   </group>
 </launch>

--- a/audio_play/launch/play.launch
+++ b/audio_play/launch/play.launch
@@ -5,6 +5,7 @@
   <arg name="format" default="mp3"/>
   <arg name="channels" default="1"/>
   <arg name="sample_rate" default="16000"/>
+  <arg name="sample_format" default="S16LE"/>
 
   <group ns="$(arg ns)">
   <node name="audio_play" pkg="audio_play" type="audio_play" output="screen">
@@ -13,6 +14,7 @@
     <param name="format" value="$(arg format)"/>
     <param name="channels" value="$(arg channels)"/>
     <param name="sample_rate" value="$(arg sample_rate)"/>
+    <param name="sample_format" value="$(arg sample_format)"/>
   </node>
   </group>
 </launch>

--- a/audio_play/launch/play.launch
+++ b/audio_play/launch/play.launch
@@ -3,12 +3,16 @@
   <arg name="dst" default="alsasink"/>
   <arg name="do_timestamp" default="true"/>
   <arg name="format" default="mp3"/>
+  <arg name="channels" default="1"/>
+  <arg name="sample_rate" default="16000"/>
 
   <group ns="$(arg ns)">
   <node name="audio_play" pkg="audio_play" type="audio_play" output="screen">
     <param name="dst" value="$(arg dst)"/>
     <param name="do_timestamp" value="$(arg do_timestamp)"/>
     <param name="format" value="$(arg format)"/>
+    <param name="channels" value="$(arg channels)"/>
+    <param name="sample_rate" value="$(arg sample_rate)"/>
   </node>
   </group>
 </launch>

--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -17,11 +17,13 @@ namespace audio_transport
         std::string dst_type;
         std::string device;
         bool do_timestamp;
+        std::string format;
 
         // The destination of the audio
         ros::param::param<std::string>("~dst", dst_type, "alsasink");
         ros::param::param<std::string>("~device", device, std::string());
         ros::param::param<bool>("~do_timestamp", do_timestamp, true);
+        ros::param::param<std::string>("~format", format, "mp3");
 
         _sub = _nh.subscribe("audio", 10, &RosGstPlay::onAudio, this);
 
@@ -30,30 +32,48 @@ namespace audio_transport
         _pipeline = gst_pipeline_new("app_pipeline");
         _source = gst_element_factory_make("appsrc", "app_source");
         g_object_set(G_OBJECT(_source), "do-timestamp", (do_timestamp) ? TRUE : FALSE, NULL);
-        gst_bin_add( GST_BIN(_pipeline), _source);
 
         //_playbin = gst_element_factory_make("playbin2", "uri_play");
         //g_object_set( G_OBJECT(_playbin), "uri", "file:///home/test/test.mp3", NULL);
         if (dst_type == "alsasink")
         {
-          _decoder = gst_element_factory_make("decodebin", "decoder");
-          g_signal_connect(_decoder, "pad-added", G_CALLBACK(cb_newpad),this);
-          gst_bin_add( GST_BIN(_pipeline), _decoder);
-          gst_element_link(_source, _decoder);
+          if (format == "mp3")
+          {
+            gst_bin_add( GST_BIN(_pipeline), _source);
+            _decoder = gst_element_factory_make("decodebin", "decoder");
+            g_signal_connect(_decoder, "pad-added", G_CALLBACK(cb_newpad),this);
+            gst_bin_add( GST_BIN(_pipeline), _decoder);
+            gst_element_link(_source, _decoder);
 
-          _audio = gst_bin_new("audiobin");
-          _convert = gst_element_factory_make("audioconvert", "convert");
-          audiopad = gst_element_get_static_pad(_convert, "sink");
-          _sink = gst_element_factory_make("autoaudiosink", "sink");
-          if (!device.empty()) {
-            g_object_set(G_OBJECT(_sink), "device", device.c_str(), NULL);
+            _audio = gst_bin_new("audiobin");
+            _convert = gst_element_factory_make("audioconvert", "convert");
+            audiopad = gst_element_get_static_pad(_convert, "sink");
+            _sink = gst_element_factory_make("autoaudiosink", "sink");
+            if (!device.empty()) {
+              g_object_set(G_OBJECT(_sink), "device", device.c_str(), NULL);
+            }
+            gst_bin_add_many( GST_BIN(_audio), _convert, _sink, NULL);
+            gst_element_link(_convert, _sink);
+            gst_element_add_pad(_audio, gst_ghost_pad_new("sink", audiopad));
+            gst_object_unref(audiopad);
+
+            gst_bin_add(GST_BIN(_pipeline), _audio);
           }
-          gst_bin_add_many( GST_BIN(_audio), _convert, _sink, NULL);
-          gst_element_link(_convert, _sink);
-          gst_element_add_pad(_audio, gst_ghost_pad_new("sink", audiopad));
-          gst_object_unref(audiopad);
-
-          gst_bin_add(GST_BIN(_pipeline), _audio);
+          else if (format == "wave")
+          {
+            GstCaps *caps;
+            caps = gst_caps_from_string("audio/x-raw,format=S16LE,rate=16000,channels=1,layout=interleaved");
+            g_object_set( G_OBJECT(_source), "caps", caps, NULL);
+            gst_caps_unref(caps);
+            g_object_set (G_OBJECT (_source), "format", GST_FORMAT_TIME, NULL);
+            _sink = gst_element_factory_make( "autoaudiosink", "sink" );
+            gst_bin_add_many( GST_BIN(_pipeline), _source, _sink, NULL);
+            gst_element_link_many( _source, _sink, NULL);
+          }
+          else
+          {
+            ROS_ERROR("Unsupported format: %s", format.c_str());
+          }
         }
         else
         {

--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -20,6 +20,7 @@ namespace audio_transport
         std::string format;
         int channels;
         int sample_rate;
+        std::string sample_format;
 
         // The destination of the audio
         ros::param::param<std::string>("~dst", dst_type, "alsasink");
@@ -28,6 +29,7 @@ namespace audio_transport
         ros::param::param<std::string>("~format", format, "mp3");
         ros::param::param<int>("~channels", channels, 1);
         ros::param::param<int>("~sample_rate", sample_rate, 16000);
+        ros::param::param<std::string>("~sample_format", sample_format, "S16LE");
 
         _sub = _nh.subscribe("audio", 10, &RosGstPlay::onAudio, this);
 
@@ -68,7 +70,7 @@ namespace audio_transport
             GstCaps *caps;
             caps = gst_caps_new_simple(
                 "audio/x-raw",
-                "format", G_TYPE_STRING, "S16LE",
+                "format", G_TYPE_STRING, sample_format.c_str(),
                 "rate", G_TYPE_INT, sample_rate,
                 "channels", G_TYPE_INT, channels,
                 "layout", G_TYPE_STRING, "interleaved",

--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -18,12 +18,16 @@ namespace audio_transport
         std::string device;
         bool do_timestamp;
         std::string format;
+        int channels;
+        int sample_rate;
 
         // The destination of the audio
         ros::param::param<std::string>("~dst", dst_type, "alsasink");
         ros::param::param<std::string>("~device", device, std::string());
         ros::param::param<bool>("~do_timestamp", do_timestamp, true);
         ros::param::param<std::string>("~format", format, "mp3");
+        ros::param::param<int>("~channels", channels, 1);
+        ros::param::param<int>("~sample_rate", sample_rate, 16000);
 
         _sub = _nh.subscribe("audio", 10, &RosGstPlay::onAudio, this);
 
@@ -62,7 +66,13 @@ namespace audio_transport
           else if (format == "wave")
           {
             GstCaps *caps;
-            caps = gst_caps_from_string("audio/x-raw,format=S16LE,rate=16000,channels=1,layout=interleaved");
+            caps = gst_caps_new_simple(
+                "audio/x-raw",
+                "format", G_TYPE_STRING, "S16LE",
+                "rate", G_TYPE_INT, sample_rate,
+                "channels", G_TYPE_INT, channels,
+                "layout", G_TYPE_STRING, "interleaved",
+                NULL);
             g_object_set( G_OBJECT(_source), "caps", caps, NULL);
             gst_caps_unref(caps);
             g_object_set (G_OBJECT (_source), "format", GST_FORMAT_TIME, NULL);


### PR DESCRIPTION
related to #104 
support wave format for audio_play.
I also use #122 for audio livestreaming by wave format as respeaker_node in https://github.com/jsk-ros-pkg/jsk_3rdparty