### PR TITLE
Handle playing sound in loop

### DIFF
--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -52,6 +52,7 @@ try:
     import gi
     gi.require_version('Gst', '1.0')
     from gi.repository import Gst as Gst
+    from gi.repository import GObject as GObject
 except:
     str="""
 **************************************************************
@@ -62,7 +63,6 @@ Error opening pygst. Is gstreamer installed?
     # print str
     exit(1)
 
-from gi.repository import GObject as GObject
 
 def sleep(t):
     try:


### PR DESCRIPTION
Handle playing sound in loop by:
* starting gobject thread to receive gstreamer messages
* seeking file beginning instead of stopping playback
* fixing a bug where all wave files where flagged as stale
* allowing multiple sound plays at the same time