### PR TITLE
[audio_play, audio_capture] support sample_rate, sample_format, channels for mp3

### DIFF
--- a/audio_capture/src/audio_capture.cpp
+++ b/audio_capture/src/audio_capture.cpp
@@ -75,29 +75,28 @@ namespace audio_transport
           g_object_set(G_OBJECT(_source), "device", device.c_str(), NULL);
         }
 
-        _filter = gst_element_factory_make("capsfilter", "filter");
-        {
-          GstCaps *caps;
-          caps = gst_caps_new_simple("audio/x-raw",
-                        //      "channels", G_TYPE_INT, _channels,
-                        //      "depth",    G_TYPE_INT, _depth,
-                              "format", G_TYPE_STRING, _sample_format.c_str(),
-                              "rate",     G_TYPE_INT, _sample_rate,
-                        //       "signed",   G_TYPE_BOOLEAN, TRUE,
-                              NULL);
-          g_object_set( G_OBJECT(_filter), "caps", caps, NULL);
-          gst_caps_unref(caps);
-        }
-
-        _convert = gst_element_factory_make("audioconvert", "convert");
-        if (!_convert) {
-      	  ROS_ERROR_STREAM("Failed to create audioconvert element");
-      	  exitOnMainThread(1);
-        }
 
         gboolean link_ok;
 
         if (_format == "mp3"){
+          _filter = gst_element_factory_make("capsfilter", "filter");
+          GstCaps *caps;
+          caps = gst_caps_new_simple("audio/x-raw",
+                                     "format", G_TYPE_STRING, _sample_format.c_str(),
+                                     "channels", G_TYPE_INT, _channels,
+                                     "rate",     G_TYPE_INT, _sample_rate,
+                                     // "depth",    G_TYPE_INT, _depth,
+                                     // "signed",   G_TYPE_BOOLEAN, TRUE,
+                                     NULL);
+          g_object_set( G_OBJECT(_filter), "caps", caps, NULL);
+          gst_caps_unref(caps);
+
+          _convert = gst_element_factory_make("audioconvert", "convert");
+          if (!_convert) {
+        	  ROS_ERROR_STREAM("Failed to create audioconvert element");
+        	  exitOnMainThread(1);
+          }
+
           _encode = gst_element_factory_make("lamemp3enc", "encoder");
           if (!_encode) {
         	  ROS_ERROR_STREAM("Failed to create encoder element");

--- a/audio_capture/src/audio_capture.cpp
+++ b/audio_capture/src/audio_capture.cpp
@@ -93,14 +93,14 @@ namespace audio_transport
 
           _convert = gst_element_factory_make("audioconvert", "convert");
           if (!_convert) {
-        	  ROS_ERROR_STREAM("Failed to create audioconvert element");
-        	  exitOnMainThread(1);
+            ROS_ERROR_STREAM("Failed to create audioconvert element");
+            exitOnMainThread(1);
           }
 
           _encode = gst_element_factory_make("lamemp3enc", "encoder");
           if (!_encode) {
-        	  ROS_ERROR_STREAM("Failed to create encoder element");
-        	  exitOnMainThread(1);
+            ROS_ERROR_STREAM("Failed to create encoder element");
+            exitOnMainThread(1);
           }
           g_object_set( G_OBJECT(_encode), "quality", 2.0, NULL);
           g_object_set( G_OBJECT(_encode), "bitrate", _bitrate, NULL);

--- a/audio_capture/src/audio_capture.cpp
+++ b/audio_capture/src/audio_capture.cpp
@@ -75,19 +75,19 @@ namespace audio_transport
           g_object_set(G_OBJECT(_source), "device", device.c_str(), NULL);
         }
 
+        GstCaps *caps;
+        caps = gst_caps_new_simple("audio/x-raw",
+                                   "format", G_TYPE_STRING, _sample_format.c_str(),
+                                   "channels", G_TYPE_INT, _channels,
+                                   "width",    G_TYPE_INT, _depth,
+                                   "depth",    G_TYPE_INT, _depth,
+                                   "rate",     G_TYPE_INT, _sample_rate,
+                                   "signed",   G_TYPE_BOOLEAN, TRUE,
+                                   NULL);
 
         gboolean link_ok;
-
         if (_format == "mp3"){
           _filter = gst_element_factory_make("capsfilter", "filter");
-          GstCaps *caps;
-          caps = gst_caps_new_simple("audio/x-raw",
-                                     "format", G_TYPE_STRING, _sample_format.c_str(),
-                                     "channels", G_TYPE_INT, _channels,
-                                     "rate",     G_TYPE_INT, _sample_rate,
-                                     // "depth",    G_TYPE_INT, _depth,
-                                     // "signed",   G_TYPE_BOOLEAN, TRUE,
-                                     NULL);
           g_object_set( G_OBJECT(_filter), "caps", caps, NULL);
           gst_caps_unref(caps);
 
@@ -108,16 +108,6 @@ namespace audio_transport
           gst_bin_add_many( GST_BIN(_pipeline), _source, _filter, _convert, _encode, _sink, NULL);
           link_ok = gst_element_link_many(_source, _filter, _convert, _encode, _sink, NULL);
         } else if (_format == "wave") {
-          GstCaps *caps;
-          caps = gst_caps_new_simple("audio/x-raw",
-                                     "format", G_TYPE_STRING, _sample_format.c_str(),
-                                     "channels", G_TYPE_INT, _channels,
-                                     "width",    G_TYPE_INT, _depth,
-                                     "depth",    G_TYPE_INT, _depth,
-                                     "rate",     G_TYPE_INT, _sample_rate,
-                                     "signed",   G_TYPE_BOOLEAN, TRUE,
-                                     NULL);
-
           if (dst_type == "appsink") {
             g_object_set( G_OBJECT(_sink), "caps", caps, NULL);
             gst_caps_unref(caps);


### PR DESCRIPTION
support `sample_rate`, `sample_format`, `channels` for `mp3` in `audio_capture` and `audio_play`.
`sample_format` is introduced in #127 and #145 .