### PR TITLE
[audio_common_msgs] Add new audio msgs

### DIFF
--- a/audio_common_msgs/CMakeLists.txt
+++ b/audio_common_msgs/CMakeLists.txt
@@ -2,8 +2,12 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(audio_common_msgs)
 
-find_package(catkin REQUIRED COMPONENTS message_generation)
-add_message_files(DIRECTORY msg FILES AudioData.msg)
-generate_messages()
+find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)
+add_message_files(DIRECTORY msg FILES
+  AudioData.msg
+  CompressedAudioData.msg
+  WaveData.msg
+  )
+generate_messages(DEPENDENCIES std_msgs)
 
 catkin_package(CATKIN_DEPENDS message_runtime)

--- a/audio_common_msgs/CMakeLists.txt
+++ b/audio_common_msgs/CMakeLists.txt
@@ -5,7 +5,7 @@ project(audio_common_msgs)
 find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)
 add_message_files(DIRECTORY msg FILES
   AudioData.msg
-  CompressedAudioData.msg
+  Mp3Data.msg
   WaveData.msg
   )
 generate_messages(DEPENDENCIES std_msgs)

--- a/audio_common_msgs/msg/CompressedAudioData.msg
+++ b/audio_common_msgs/msg/CompressedAudioData.msg
@@ -1,0 +1,10 @@
+Header header      # Header timestamp should be acquisition time of audio
+                   # Header frame_id should be position of microphone
+
+uint8 channels     # Number of channels
+uint32 sample_rate # Sampling rate [Hz]
+uint32 bitrate     # Amount of audio data per second [bits/s]
+
+string format      # Specifies the format of the audio data
+                   # For example, mp3
+uint8[] data       # Compressed audio buffer

--- a/audio_common_msgs/msg/CompressedAudioData.msg
+++ b/audio_common_msgs/msg/CompressedAudioData.msg
@@ -1,10 +1,13 @@
-Header header      # Header timestamp should be acquisition time of audio
-                   # Header frame_id should be position of microphone
+Header header        # Header timestamp should be acquisition time of audio
+                     # Header frame_id should be position of microphone
 
-uint8 channels     # Number of channels
-uint32 sample_rate # Sampling rate [Hz]
-uint32 bitrate     # Amount of audio data per second [bits/s]
+uint8 channels       # Number of channels
+uint32 sample_rate   # Sampling rate [Hz]
+string sample_format # Format for Compressed audio
+                     # Format list can be given by following command
+                     # $ gst-inspect-1.0 lamemp3enc | grep format:
+uint32 bitrate       # Amount of audio data per second [bits/s]
 
-string format      # Specifies the format of the audio data
-                   # For example, mp3
-uint8[] data       # Compressed audio buffer
+string format        # Specifies the format of the audio data
+                     # For example, mp3
+uint8[] data         # Compressed audio buffer

--- a/audio_common_msgs/msg/Mp3Data.msg
+++ b/audio_common_msgs/msg/Mp3Data.msg
@@ -3,11 +3,9 @@ Header header        # Header timestamp should be acquisition time of audio
 
 uint8 channels       # Number of channels
 uint32 sample_rate   # Sampling rate [Hz]
-string sample_format # Format for Compressed audio
+string sample_format # Format for MP3 audio
                      # Format list can be given by following command
                      # $ gst-inspect-1.0 lamemp3enc | grep format:
 uint32 bitrate       # Amount of audio data per second [bits/s]
 
-string format        # Specifies the format of the audio data
-                     # For example, mp3
-uint8[] data         # Compressed audio buffer
+uint8[] data         # MP3 audio buffer

--- a/audio_common_msgs/msg/WaveData.msg
+++ b/audio_common_msgs/msg/WaveData.msg
@@ -1,0 +1,9 @@
+Header header      # Header timestamp should be acquisition time of audio
+                   # Header frame_id should be position of microphone
+
+uint8 channels     # Number of channels
+uint32 sample_rate # Sampling rate [Hz]
+uint8 depth        # Number of bits per audio data
+
+uint8[] data       # Audio data buffer
+                   # WAVE format is assumed

--- a/audio_common_msgs/msg/WaveData.msg
+++ b/audio_common_msgs/msg/WaveData.msg
@@ -1,9 +1,11 @@
-Header header      # Header timestamp should be acquisition time of audio
-                   # Header frame_id should be position of microphone
+Header header        # Header timestamp should be acquisition time of audio
+                     # Header frame_id should be position of microphone
 
-uint8 channels     # Number of channels
-uint32 sample_rate # Sampling rate [Hz]
-uint8 depth        # Number of bits per audio data
+uint8 channels       # Number of channels
+uint32 sample_rate   # Sampling rate [Hz]
+string sample_format # Format for PCM audio
+                     # Format list can be given by following command
+                     # $ gst-inspect-1.0 wavenc | grep format:
 
-uint8[] data       # Audio data buffer
-                   # WAVE format is assumed
+uint8[] data         # Audio data buffer
+                     # WAVE format is assumed


### PR DESCRIPTION
From https://github.com/ros-drivers/audio_common/issues/136
In this PR, I added new audio messages, which have more information than `AudioData.msg`

For `WaveData.msg`, I used this site as a reference.
http://soundfile.sapp.org/doc/WaveFormat/
For `CompressedAudioData.msg`, I used this site as a reference.
https://www.mp3-tech.org/programmer/frame_header.html

Each field name in these msg is the same as the rosparam in `audio_capture`.
https://github.com/ros-drivers/audio_common/blob/master/audio_capture/src/audio_capture.cpp

Here's the new msg.
This msg is a slightly modified version of the one I wrote in the above issue.

WaveData.msg:
```
Header header      # Header timestamp should be acquisition time of audio
                   # Header frame_id should be position of microphone

uint8 channels     # Number of channels
uint32 sample_rate # Sampling rate [Hz]
uint8 depth        # Number of bits per audio data

uint8[] data       # Audio data buffer
                   # WAVE format is assumed
```

CompressedAudioData.msg:
```
Header header      # Header timestamp should be acquisition time of audio
                   # Header frame_id should be position of microphone

uint8 channels     # Number of channels
uint32 sample_rate # Sampling rate [Hz]
uint32 bitrate     # Amount of audio data per second [bits/s]

string format      # Specifies the format of the audio data
                   # For example, mp3
uint8[] data       # Compressed audio buffer
```