### PR TITLE
Fix property of lamemp3enc element in audio_capture so that the bitrate parameter work properly.

### DIFF
--- a/audio_capture/src/audio_capture.cpp
+++ b/audio_capture/src/audio_capture.cpp
@@ -102,7 +102,7 @@ namespace audio_transport
             ROS_ERROR_STREAM("Failed to create encoder element");
             exitOnMainThread(1);
           }
-          g_object_set( G_OBJECT(_encode), "quality", 2.0, NULL);
+          g_object_set( G_OBJECT(_encode), "target", 1, NULL);
           g_object_set( G_OBJECT(_encode), "bitrate", _bitrate, NULL);
 
           gst_bin_add_many( GST_BIN(_pipeline), _source, _filter, _convert, _encode, _sink, NULL);


### PR DESCRIPTION
The bitrate parameter of audio capture does not affect bitrate of published messages with mp3 encoding.

This is because lamemp3enc element in audio_capture use [quality property](https://gstreamer.freedesktop.org/documentation/lame/index.html#lamemp3enc:quality) instead of [bitrate property](https://gstreamer.freedesktop.org/documentation/lame/index.html#lamemp3enc:bitrate) if [target property](https://gstreamer.freedesktop.org/documentation/lame/index.html#lamemp3enc:target) is not changed.

I confirmed that this code works properly with the following script.

```
#!/usr/bin/env python
# -*- coding:utf-8 -*-

import rospy
from audio_common_msgs.msg import AudioData
import time

class MeasureAudioBitrate:

    def __init__(self):
        #
        rospy.init_node( 'measure_audio_bitrate' )
        #
        topicname = 'audio'
        #
        self.subscriber = rospy.Subscriber( topicname, AudioData, self.cbROS )
        self.time = time.time()
        self.counter = 0
        self.length = 0

    def cbROS( self, msg ):
        self.counter += 1
        self.length += len(msg.data)
        if self.counter == 10:
            oldtime = self.time
            self.time = time.time()
            newtime = self.time
            print( "{} kbps".format( ( self.length * 8 ) / ( 1000 * ( newtime - oldtime ) ) ) )
            self.counter = 0
            self.length = 0

def main():
    a = MeasureAudioBitrate()
    rospy.spin()

if __name__=='__main__':
    main()
```

Before
```
$ rosrun audio_capture audio_capture _format:=mp3 _bitrate:=192
$ rosrun test.py
52.3826907236 kbps
44.7369462282 kbps
45.7967945055 kbps
46.1584529812 kbps
47.7050088643 kbps
46.8921918307 kbps
47.911507811 kbps
45.5643768708 kbps
47.8792240984 kbps


$ rosrun audio_capture audio_capture _format:=mp3 _bitrate:=8
$ rosrun test.py
48.4762810285 kbps
46.162254594 kbps
44.9183615653 kbps
47.8828590717 kbps
44.2231306538 kbps
46.6538685745 kbps
45.956293114 kbps
46.7140290239 kbps
45.8811741112 kbps
50.5001462092 kbps
47.0215914453 kbps
```

After
```
$ rosrun audio_capture audio_capture _format:=mp3 _bitrate:=192
$ rosrun test.py
122.154565463 kbps
109.458909606 kbps
106.712287233 kbps
107.710514829 kbps
108.627828 kbps
110.13201769 kbps
106.909510345 kbps
109.65376228 kbps
110.590932915 kbps
106.399331609 kbps

$ rosrun audio_capture audio_capture _format:=mp3 _bitrate:=8
$ rosrun test.py
11.0098257965 kbps
7.99177475937 kbps
7.19496354747 kbps
7.2970503465 kbps
7.22011725911 kbps
8.02297751432 kbps
7.97092594511 kbps
8.03757794649 kbps
```