### PR TITLE
[audio_common_msgs] AudioInfo.msg to add audio meta data

### DIFF
--- a/audio_common_msgs/CMakeLists.txt
+++ b/audio_common_msgs/CMakeLists.txt
@@ -3,7 +3,10 @@ cmake_minimum_required(VERSION 2.8.3)
 project(audio_common_msgs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation)
-add_message_files(DIRECTORY msg FILES AudioData.msg)
+add_message_files(DIRECTORY msg FILES
+  AudioData.msg
+  AudioInfo.msg
+  )
 generate_messages()
 
 catkin_package(CATKIN_DEPENDS message_runtime)

--- a/audio_common_msgs/msg/AudioInfo.msg
+++ b/audio_common_msgs/msg/AudioInfo.msg
@@ -1,0 +1,5 @@
+uint8 channels       # Number of channels
+uint32 sample_rate   # Sampling rate [Hz]
+string sample_format # Audio format (e.g. S16LE)
+uint32 bitrate       # Amount of audio data per second [bits/s]
+string coding_format # Audio coding format (e.g. WAVE, MP3)

--- a/audio_common_msgs/msg/AudioInfo.msg
+++ b/audio_common_msgs/msg/AudioInfo.msg
@@ -1,5 +1,12 @@
-uint8 channels       # Number of channels
-uint32 sample_rate   # Sampling rate [Hz]
-string sample_format # Audio format (e.g. S16LE)
-uint32 bitrate       # Amount of audio data per second [bits/s]
-string coding_format # Audio coding format (e.g. WAVE, MP3)
+# This message contains the audio meta data
+
+# Number of channels
+uint8 channels
+# Sampling rate [Hz]
+uint32 sample_rate
+# Audio format (e.g. S16LE)
+string sample_format
+# Amount of audio data per second [bits/s]
+uint32 bitrate
+# Audio coding format (e.g. WAVE, MP3)
+string coding_format


### PR DESCRIPTION
From https://github.com/ros-drivers/audio_common/pull/148

I added `AudioInfo.msg` which includes audio meta data.
This information is not necessarily required for decoding audio data, but it may be helpful for the users to do some audio processing.

CC @knorth55 @sktometometo 