### PR TITLE
fix soundplay_node to handle Python3 strings

### DIFF
--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -254,11 +254,15 @@ class soundplay:
                 voice = data.arg2
                 try:
                     try:
-                        txtfile.write(data.arg.decode('UTF-8').encode('ISO-8859-15'))
+                        if hasattr(data.arg, 'decode'):
+                            txtfile.write(data.arg.decode('UTF-8').encode('ISO-8859-15'))
+                        else:
+                            txtfile.write(data.arg.encode('ISO-8859-15'))
                     except UnicodeEncodeError:
-                        txtfile.write(data.arg)
-                    except AttributeError:
-                        txtfile.write(data.arg.encode('ISO-8859-15'))
+                        if hasattr(data.arg, 'decode'):
+                            txtfile.write(data.arg)
+                        else:
+                            txtfile.write(data.arg.encode('UTF-8'))
                     txtfile.flush()
                     os.system("text2wave -eval '("+voice+")' "+txtfilename+" -o "+wavfilename)
                     try:

--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -257,6 +257,8 @@ class soundplay:
                         txtfile.write(data.arg.decode('UTF-8').encode('ISO-8859-15'))
                     except UnicodeEncodeError:
                         txtfile.write(data.arg)
+                    except AttributeError:
+                        txtfile.write(data.arg.encode('ISO-8859-15'))
                     txtfile.flush()
                     os.system("text2wave -eval '("+voice+")' "+txtfilename+" -o "+wavfilename)
                     try:

--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -317,7 +317,7 @@ class soundplay:
     # Purge sounds that haven't been played in a while.
     def cleanupdict(self, dict):
         purgelist = []
-        for (key,sound) in dict.iteritems():
+        for (key,sound) in dict.items():
             try:
                 staleness = sound.get_staleness()
             except Exception as e:

--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -317,7 +317,7 @@ class soundplay:
     # Purge sounds that haven't been played in a while.
     def cleanupdict(self, dict):
         purgelist = []
-        for (key,sound) in dict.items():
+        for (key,sound) in iter(dict.items()):
             try:
                 staleness = sound.get_staleness()
             except Exception as e:


### PR DESCRIPTION
Currently if trying to use text-to-speech feature, the version released in noetic fails with the following error:
`$ rosrun sound_play say.py 'Hello Robot'`
```
(/sound_play) [ERROR] [1599147542.494601]: Exception in callback: 'str' object has no attribute 'decode', /tmp/test_audio_common_ws/src/audio_common/sound_play/scripts/soundplay_node.py:309
```

This PR catches the case a Python3 string is received and encodes it to file to be able to play it