### PR TITLE
remove device option from audio_play.cpp

### DIFF
--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -16,7 +16,6 @@ namespace audio_transport
         GstCaps *caps;
 
         std::string dst_type;
-        std::string device;
         bool do_timestamp;
         std::string format;
         int channels;
@@ -25,7 +24,6 @@ namespace audio_transport
 
         // The destination of the audio
         ros::param::param<std::string>("~dst", dst_type, "alsasink");
-        ros::param::param<std::string>("~device", device, std::string());
         ros::param::param<bool>("~do_timestamp", do_timestamp, true);
         ros::param::param<std::string>("~format", format, "mp3");
         ros::param::param<int>("~channels", channels, 1);
@@ -67,9 +65,6 @@ namespace audio_transport
             g_object_set(G_OBJECT(_filter), "caps", caps, NULL);
 
             _sink = gst_element_factory_make("autoaudiosink", "sink");
-            if (!device.empty()) {
-              g_object_set(G_OBJECT(_sink), "device", device.c_str(), NULL);
-            }
             gst_bin_add_many( GST_BIN(_audio), _convert, _sink, NULL);
             gst_element_link(_convert, _sink);
             gst_element_add_pad(_audio, gst_ghost_pad_new("sink", audiopad));


### PR DESCRIPTION
I tried to add `device` option in `audio_play/launch/play.launch` like this
```xml
<launch>
  <arg name="ns" default="audio"/>
  <arg name="dst" default="alsasink"/>
  <arg name="do_timestamp" default="false"/>
  <arg name="device" default="hw:0,0"/>
  <arg name="format" default="mp3"/>
  <arg name="channels" default="1"/>
  <arg name="sample_rate" default="16000"/>
  <arg name="sample_format" default="S16LE"/>

  <group ns="$(arg ns)">
  <node name="audio_play" pkg="audio_play" type="audio_play" output="screen">
    <param name="dst" value="$(arg dst)"/>
    <param name="do_timestamp" value="$(arg do_timestamp)"/>
    <param name="device" value="$(arg device)"/>
    <param name="format" value="$(arg format)"/>
    <param name="channels" value="$(arg channels)"/>
    <param name="sample_rate" value="$(arg sample_rate)"/>
    <param name="sample_format" value="$(arg sample_format)"/>
  </node>
  </group>
</launch>
```
and roslaunch returned the warning.
```
(audio_play:29143): GLib-GObject-WARNING **: 14:24:09.282: g_object_set_is_valid_property: object class 'GstAutoAudioSink' has no property named 'device'
```
It seems there are no property named `device` in autoaudiosink element used in audio_play node, so I removed the device paramater in the node.
https://gstreamer.freedesktop.org/documentation/autodetect/autoaudiosink.html?gi-language=c#autoaudiosink-page