### PR TITLE
[audio_play] use alsasink and add device 

### DIFF
--- a/audio_capture/src/audio_capture.cpp
+++ b/audio_capture/src/audio_capture.cpp
@@ -59,7 +59,7 @@ namespace audio_transport
         }
         else
         {
-          printf("file sink\n");
+          ROS_INFO("file sink to %s", dst_type.c_str());
           _sink = gst_element_factory_make("filesink", "sink");
           g_object_set( G_OBJECT(_sink), "location", dst_type.c_str(), NULL);
         }

--- a/audio_play/launch/play.launch
+++ b/audio_play/launch/play.launch
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="device" default=""/>
   <arg name="ns" default="audio"/>
   <arg name="dst" default="alsasink"/>
   <arg name="do_timestamp" default="false"/>
@@ -9,6 +10,7 @@
 
   <group ns="$(arg ns)">
   <node name="audio_play" pkg="audio_play" type="audio_play" output="screen">
+    <param name="device" value="$(arg device)"/>
     <param name="dst" value="$(arg dst)"/>
     <param name="do_timestamp" value="$(arg do_timestamp)"/>
     <param name="format" value="$(arg format)"/>

--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -100,6 +100,9 @@ namespace audio_transport
           {
             _sink = gst_element_factory_make("alsasink", "sink" );
             g_object_set(G_OBJECT(_sink), "sync", FALSE, NULL);
+            if (!device.empty()) {
+              g_object_set(G_OBJECT(_sink), "device", device.c_str(), NULL);
+            }
             gst_bin_add_many( GST_BIN(_pipeline), _source, _sink, NULL);
             gst_element_link_many( _source, _sink, NULL);
           }

--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -20,6 +20,7 @@ namespace audio_transport
         bool do_timestamp;
         std::string format;
         int channels;
+        int depth;
         int sample_rate;
         std::string sample_format;
 
@@ -29,6 +30,7 @@ namespace audio_transport
         ros::param::param<bool>("~do_timestamp", do_timestamp, true);
         ros::param::param<std::string>("~format", format, "mp3");
         ros::param::param<int>("~channels", channels, 1);
+        ros::param::param<int>("~depth", depth, 16);
         ros::param::param<int>("~sample_rate", sample_rate, 16000);
         ros::param::param<std::string>("~sample_format", sample_format, "S16LE");
 
@@ -47,6 +49,9 @@ namespace audio_transport
             "format", G_TYPE_STRING, sample_format.c_str(),
             "rate", G_TYPE_INT, sample_rate,
             "channels", G_TYPE_INT, channels,
+            "width",    G_TYPE_INT, depth,
+            "depth",    G_TYPE_INT, depth,
+            "signed",   G_TYPE_BOOLEAN, TRUE,
             "layout", G_TYPE_STRING, "interleaved",
             NULL);
         if (format == "mp3")

--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -71,7 +71,7 @@ namespace audio_transport
             _filter = gst_element_factory_make("capsfilter", "filter");
             g_object_set(G_OBJECT(_filter), "caps", caps, NULL);
 
-            _sink = gst_element_factory_make("autoaudiosink", "sink");
+            _sink = gst_element_factory_make("alsasink", "sink");
             if (!device.empty()) {
               g_object_set(G_OBJECT(_sink), "device", device.c_str(), NULL);
             }
@@ -97,7 +97,7 @@ namespace audio_transport
           g_object_set (G_OBJECT (_source), "format", GST_FORMAT_TIME, NULL);
           if (dst_type == "alsasink")
           {
-            _sink = gst_element_factory_make( "autoaudiosink", "sink" );
+            _sink = gst_element_factory_make("alsasink", "sink" );
             gst_bin_add_many( GST_BIN(_pipeline), _source, _sink, NULL);
             gst_element_link_many( _source, _sink, NULL);
           }

--- a/audio_play/src/audio_play.cpp
+++ b/audio_play/src/audio_play.cpp
@@ -72,6 +72,7 @@ namespace audio_transport
             g_object_set(G_OBJECT(_filter), "caps", caps, NULL);
 
             _sink = gst_element_factory_make("alsasink", "sink");
+            g_object_set(G_OBJECT(_sink), "sync", FALSE, NULL);
             if (!device.empty()) {
               g_object_set(G_OBJECT(_sink), "device", device.c_str(), NULL);
             }
@@ -98,6 +99,7 @@ namespace audio_transport
           if (dst_type == "alsasink")
           {
             _sink = gst_element_factory_make("alsasink", "sink" );
+            g_object_set(G_OBJECT(_sink), "sync", FALSE, NULL);
             gst_bin_add_many( GST_BIN(_pipeline), _source, _sink, NULL);
             gst_element_link_many( _source, _sink, NULL);
           }


### PR DESCRIPTION
This PR fixes `device` option warning reported in #159 .
Without this PR, `device` param is not correctly passed to gstreamer.

```
(audio_play:29143): GLib-GObject-WARNING **: 14:24:09.282: g_object_set_is_valid_property: object class 'GstAutoAudioSink' has no property named 'device'
```

- add `device` arg for `audio_play` `play.launch`
- add `depth` param in `audio_play` node
- use `alsasink`
  - add `sync:false` for `alsasink`