### PR TITLE
Modified loop rate for action execution

### DIFF
--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -395,7 +395,7 @@ class soundplay:
                 sound = self.select_sound(data)
                 sound.command(data.command)
 
-                r = rospy.Rate(1)
+                r = rospy.Rate(self.loop_rate)
                 start_time = rospy.get_rostime()
                 success = True
                 while sound.get_playing():
@@ -436,6 +436,7 @@ class soundplay:
         self.g_loop.start()
 
         rospy.init_node('sound_play')
+        self.loop_rate = rospy.get_param('~loop_rate', 100)
         self.device = rospy.get_param("~device", "default")
         self.diagnostic_pub = rospy.Publisher("/diagnostics", DiagnosticArray, queue_size=1)
         rootdir = os.path.join(roslib.packages.get_pkg_dir('sound_play'),'sounds')

--- a/sound_play/soundplay_node.launch
+++ b/sound_play/soundplay_node.launch
@@ -5,7 +5,9 @@ sounds based on messages on the robotsound topic.
 
 <launch>
   <arg name="device" default="" />
+  <arg name="loop_rate" default="100" />
   <node name="soundplay_node" pkg="sound_play" type="soundplay_node.py">
     <param name="device" value="$(arg device)" />
+    <param name="loop_rate" value="$(arg loop_rate)" />
   </node>
 </launch>


### PR DESCRIPTION
# What is this

In current,  `sound_play`'s action server sleep `1.0 second`.
This sleep is a little long.
Some sounds take extra time to finish speaking.
This PR modifies the sleep time.

## Example

The sample code is as follows.
```
from datetime import datetime

import rospy
from sound_play.libsoundplay import SoundClient

rospy.init_node('say_node')

client = SoundClient(
    sound_action='sound_play', sound_topic='sound_play',
    blocking=True)
rospy.sleep(2.0)


while not rospy.is_shutdown():
    start = datetime.now()
    client.say('hello!')
    end = datetime.now()
    print(end - start)
```

### Same sleep time as before
```
roslaunch sound_play soundplay_node.launch loop_rate:=1
```
The result of the above code is as follows.

```
0:00:02.182967
0:00:02.020315
0:00:02.021195
0:00:02.020535
0:00:02.019667
0:00:02.019659
0:00:02.020918
```

### Case of loop_rate:=10
```
roslaunch sound_play soundplay_node.launch loop_rate:=10
```

The result of the above code is as follows.

```
0:00:01.379812
0:00:01.217908
0:00:01.218733
0:00:01.214405
```

### Case of loop_rate:=100
```
roslaunch sound_play soundplay_node.launch loop_rate:=100
```

The result of the above code is as follows.

```
0:00:01.313113
0:00:01.137732
0:00:01.136528
0:00:01.206873
0:00:01.137762
0:00:01.137357
```