### PR TITLE
Add timeout to wait_for_server and wait_for_result

### DIFF
--- a/sound_play/src/sound_play/libsoundplay.py
+++ b/sound_play/src/sound_play/libsoundplay.py
@@ -302,8 +302,11 @@ class SoundClient(object):
     def stopAll(self):
         self.stop(SoundRequest.ALL)
 
-    def sendMsg(self, snd, cmd, s, arg2="", vol=1.0, replace=True,\
-                timeout_server=rospy.Duration(), timeout_result=rospy.Duration(), **kwargs):
+    def sendMsg(
+        self, snd, cmd, s, arg2="", vol=1.0, replace=True,
+        server_timeout=rospy.Duration(),result_timeout=rospy.Duration(),
+        **kwargs
+    ):
         """
         Internal method that publishes the sound request, either directly as a
         SoundRequest to the soundplay_node or through the actionlib interface
@@ -345,14 +348,15 @@ class SoundClient(object):
         else:  # Block until result comes back.
             assert self.actionclient, 'Actionclient must exist'
             rospy.logdebug('Sending action client sound request [blocking]')
-            if self.actionclient.wait_for_server(timeout=timeout_server):
-                goal = SoundRequestGoal()
-                goal.sound_request = msg
-                while not replace and self._playing:
-                    rospy.sleep(0.1)
-                self.actionclient.send_goal(goal)
-                if self.actionclient.wait_for_result(timeout=timeout_result):
-                    rospy.logdebug('sound request response received')
+            if not self.actionclient.wait_for_server(timeout=server_timeout):
+                return
+            goal = SoundRequestGoal()
+            goal.sound_request = msg
+            while not replace and self._playing:
+                rospy.sleep(0.1)
+            self.actionclient.send_goal(goal)
+            if self.actionclient.wait_for_result(timeout=result_timeout):
+                rospy.logdebug('sound request response received')
         return
 
     def _action_status_cb(self, msg):


### PR DESCRIPTION
Currently `sendMsg()` does not return when action server does not exist or no result is sent because timeout of `wait_for_server()` and `wait_for_result()` is set to zero. 
Some users want to escape the function even if action cannot be executed.
https://github.com/jsk-ros-pkg/jsk_robot/blob/34a129462403878c9b4c9c86c1aa9b38d506c143/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py#L34 
https://github.com/jsk-ros-pkg/jsk_robot/pull/1589#discussion_r967561657