### PR TITLE
add rosidl_generator_py in buildtool_depend

### DIFF
--- a/sound_play/package.xml
+++ b/sound_play/package.xml
@@ -19,6 +19,7 @@
    <buildtool_depend>ament_cmake</buildtool_depend>
    <buildtool_depend>ament_cmake_python</buildtool_depend>
    <buildtool_depend>rosidl_default_generators</buildtool_depend>
+   <buildtool_depend>rosidl_generator_py</buildtool_depend>
    <buildtool_depend>python3-setuptools</buildtool_depend>
 
    <build_depend>action_msgs</build_depend>


### PR DESCRIPTION
this PR adds missing `rosidl_generator_py` in `buildtool_depend`.