### PR TITLE
[audio_play] Add record_to_file.launch

### DIFF
--- a/audio_play/launch/record_to_file.launch
+++ b/audio_play/launch/record_to_file.launch
@@ -1,0 +1,25 @@
+<launch>
+  <arg name="dst" default="/tmp/output_audio.mp3"/>
+  <arg name="device" default=""/>
+  <arg name="do_timestamp" default="false"/>
+  <arg name="format" default="mp3"/>
+  <arg name="channels" default="1"/>
+  <arg name="depth" default="16"/>
+  <arg name="sample_rate" default="16000"/>
+  <arg name="sample_format" default="S16LE"/>
+  <arg name="ns" default="audio"/>
+  <arg name="audio_topic" default="audio" />
+
+  <include file="$(find audio_play)/launch/play.launch">
+    <arg name="dst" value="$(arg dst)"/>
+    <arg name="device" value="$(arg device)"/>
+    <arg name="do_timestamp" value="$(arg do_timestamp)"/>
+    <arg name="format" value="$(arg format)"/>
+    <arg name="channels" value="$(arg channels)"/>
+    <arg name="depth" value="$(arg depth)"/>
+    <arg name="sample_rate" value="$(arg sample_rate)"/>
+    <arg name="sample_format" value="$(arg sample_format)"/>
+    <arg name="ns" value="$(arg ns)"/>
+    <arg name="audio_topic" value="$(arg audio_topic)" />
+  </include>
+</launch>


### PR DESCRIPTION
Related to https://github.com/jsk-ros-pkg/jsk_common/pull/1791
There is [a function to save audio topics to a file](https://github.com/ros-drivers/audio_common/blob/836aa62522764ee7b8e4925b87ec7d84cfdd552c/audio_play/src/audio_play.cpp#L74-L79 ) in `audio_play` , but it is currently difficult to find, so I wrote a record_to_file.launch file following the example of `audio_capture`'s `capture_to_file.launch`.