### PR TITLE
Always use capsfilter/audioconvert in pipeline

### DIFF
--- a/audio_capture/src/audio_capture_node.cpp
+++ b/audio_capture/src/audio_capture_node.cpp
@@ -108,17 +108,18 @@ namespace audio_capture
                                    "signed",   G_TYPE_BOOLEAN, TRUE,
                                    NULL);
 
+        _capsfilter = gst_element_factory_make("capsfilter", "filter");
+        g_object_set( G_OBJECT(_capsfilter), "caps", caps, NULL);
+
+        _convert = gst_element_factory_make("audioconvert", "convert");
+        if (!_convert) {
+          RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to create audioconvert element");
+          exitOnMainThread(1);
+        }
+
         gboolean link_ok;
         if (_format == "mp3"){
-          _filter = gst_element_factory_make("capsfilter", "filter");
-          g_object_set( G_OBJECT(_filter), "caps", caps, NULL);
           gst_caps_unref(caps);
-
-          _convert = gst_element_factory_make("audioconvert", "convert");
-          if (!_convert) {
-            RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to create audioconvert element");
-            exitOnMainThread(1);
-          }
 
           _encode = gst_element_factory_make("lamemp3enc", "encoder");
           if (!_encode) {
@@ -128,19 +129,19 @@ namespace audio_capture
           g_object_set( G_OBJECT(_encode), "target", 1, NULL);
           g_object_set( G_OBJECT(_encode), "bitrate", _bitrate, NULL);
 
-          gst_bin_add_many( GST_BIN(_pipeline), _source, _filter, _convert, _encode, _sink, NULL);
-          link_ok = gst_element_link_many(_source, _filter, _convert, _encode, _sink, NULL);
+          gst_bin_add_many( GST_BIN(_pipeline), _source, _capsfilter, _convert, _encode, _sink, NULL);
+          link_ok = gst_element_link_many(_source, _capsfilter, _convert, _encode, _sink, NULL);
         } else if (_format == "wave") {
           if (dst_type == "appsink") {
             g_object_set( G_OBJECT(_sink), "caps", caps, NULL);
-            gst_caps_unref(caps);
-            gst_bin_add_many( GST_BIN(_pipeline), _source, _sink, NULL);
-            link_ok = gst_element_link_many( _source, _sink, NULL);
+            gst_bin_add_many( GST_BIN(_pipeline), _source, _capsfilter, _convert, _sink, NULL);
+            link_ok = gst_element_link_many( _source, _capsfilter, _convert, _sink, NULL);
           } else {
-            _filter = gst_element_factory_make("wavenc", "filter");
-            gst_bin_add_many( GST_BIN(_pipeline), _source, _filter, _sink, NULL);
-            link_ok = gst_element_link_many( _source, _filter, _sink, NULL);
+            _encode = gst_element_factory_make("wavenc", "filter");
+            gst_bin_add_many( GST_BIN(_pipeline), _source, _capsfilter, _convert, _encode, _sink, NULL);
+            link_ok = gst_element_link_many( _source, _capsfilter, _convert, _encode, _sink, NULL);
           }
+          gst_caps_unref(caps);
         } else {
           RCLCPP_ERROR_STREAM(this->get_logger(), "format must be \"wave\" or \"mp3\"");
           exitOnMainThread(1);
@@ -251,7 +252,7 @@ namespace audio_capture
 
       boost::thread _gst_thread;
 
-      GstElement *_pipeline, *_source, *_filter, *_sink, *_convert, *_encode;
+      GstElement *_pipeline, *_source, *_capsfilter, *_sink, *_convert, *_encode;
       GstBus *_bus;
       int _bitrate, _channels, _depth, _sample_rate;
       GMainLoop *_loop;


### PR DESCRIPTION
Downstream sink (appsink specifically) has trouble negotiating when using pulsesrc, so unconditionally use the audioconvert filter so that the resulting format is always available.