### PR TITLE
festival_plugin: add support for different encodings

### DIFF
--- a/sound_play/src/sound_play/festival_plugin.py
+++ b/sound_play/src/sound_play/festival_plugin.py
@@ -16,6 +16,9 @@ class FestivalPlugin(SoundPlayPlugin):
     def sound_play_say_plugin(self, text, voice):
         if voice is None or voice == '':
             voice = self._default_voice
+        encoding = 'ISO-8859-15'
+        if ':' in voice:
+            voice, encoding = voice.split(':', maxsplit=1)
         txtfile = tempfile.NamedTemporaryFile(
             prefix='sound_play', suffix='.txt')
         (wavfile, wavfilename) = tempfile.mkstemp(
@@ -26,10 +29,10 @@ class FestivalPlugin(SoundPlayPlugin):
             try:
                 if hasattr(text, 'decode'):
                     txtfile.write(
-                        text.decode('UTF-8').encode('ISO-8859-15'))
+                        text.decode('UTF-8').encode(encoding))
                 else:
                     txtfile.write(
-                        text.encode('ISO-8859-15'))
+                        text.encode(encoding))
             except UnicodeEncodeError:
                 if hasattr(text, 'decode'):
                     txtfile.write(text)


### PR DESCRIPTION
Needed for e.g. festival-czech, which expects source text in ISO-8859-2.

The implementation tries to be as unintrusive as possible. No previous use-cases should be broken (except for voices with `:` in their name, but I don't think there are any).

To test:

```bash
sudo apt install festival-czech
rosrun sound_play soundplay_node.py &
rostopic pub -1 /robotsound sound_play/SoundRequest "{sound: -3, command: 1, volume: 1.0, arg: 'Ahoj lidi a roboti, jak se máte? Testujeme háčky a čárky', arg2: 'voice_czech_ph:ISO-8859-2'}"
```

Without the correct encoding, you hear "neznámý" several times instead of the diacritics: https://translate.google.com/?sl=cs&tl=en&text=nezn%C3%A1m%C3%BD&op=translate .