### PR TITLE
Added volume control parameter at audio_capture/play

### DIFF
--- a/audio_capture/launch/capture.launch
+++ b/audio_capture/launch/capture.launch
@@ -12,6 +12,8 @@
   <arg name="sample_format" default="S16LE"/>
   <arg name="ns" default="audio"/>
   <arg name="audio_topic" default="audio"/>
+  <arg name="capture_volume" default="50"/>
+
 
   <group ns="$(arg ns)">
     <node name="audio_capture" pkg="audio_capture" type="audio_capture" output="screen">
@@ -24,6 +26,7 @@
       <param name="depth" value="$(arg depth)"/>
       <param name="sample_rate" value="$(arg sample_rate)"/>
       <param name="sample_format" value="$(arg sample_format)"/>
+      <param name="capture_volume" value="$(arg capture_volume)"/>
     </node>
   </group>
 

--- a/audio_play/launch/play.launch
+++ b/audio_play/launch/play.launch
@@ -12,6 +12,8 @@
   <arg name="sample_format" default="S16LE"/>
   <arg name="ns" default="audio"/>
   <arg name="audio_topic" default="audio" />
+  <arg name="play_volume" default="50"/>
+
 
   <group ns="$(arg ns)">
     <node name="audio_play" pkg="audio_play" type="audio_play" output="screen">
@@ -24,6 +26,7 @@
       <param name="depth" value="$(arg depth)"/>
       <param name="sample_rate" value="$(arg sample_rate)"/>
       <param name="sample_format" value="$(arg sample_format)"/>
+      <param name="play_volume" value="$(arg play_volume)"/>
     </node>
   </group>
 </launch>


### PR DESCRIPTION
In sound play, there is a volume arg which can control the output volume
but in audio_capture and audio_play, there are no option to control the volume
So I added the volume parameter at audio_capture/audio_play as ~capture_volume/~play_volume