### PR TITLE
Depend on pkg-config where needed

### DIFF
--- a/audio_capture/package.xml
+++ b/audio_capture/package.xml
@@ -19,6 +19,7 @@
    <url type="bugtracker">https://github.com/ros-drivers/audio_common/issues</url>
 
    <buildtool_depend>ament_cmake</buildtool_depend>
+   <buildtool_depend>pkg-config</buildtool_depend>
 
    <build_depend>audio_common_msgs</build_depend>
    <build_depend>boost</build_depend>

--- a/audio_play/package.xml
+++ b/audio_play/package.xml
@@ -17,6 +17,7 @@
    <url type="bugtracker">https://github.com/ros-drivers/audio_common/issues</url>
 
    <buildtool_depend>ament_cmake</buildtool_depend>
+   <buildtool_depend>pkg-config</buildtool_depend>
 
    <build_depend>audio_common_msgs</build_depend>
    <build_depend>boost</build_depend>


### PR DESCRIPTION
Packages `audio_play` and `audio_capture` need `pkg-config`, i.e. they have `find_package(PkgConfig)` in `CMakeLists.txt`. Therefore they should declare it as dependency.