### PR TITLE
make onAudio cb use references of message instead of shared ptr

### DIFF
--- a/audio_play/src/audio_play_node.cpp
+++ b/audio_play/src/audio_play_node.cpp
@@ -145,10 +145,10 @@ namespace audio_play
 
     private:
 
-      void onAudio(const audio_common_msgs::msg::AudioData::SharedPtr msg) const
+      void onAudio(const audio_common_msgs::msg::AudioData & msg) const
       {
-        GstBuffer *buffer = gst_buffer_new_and_alloc(msg->data.size());
-        gst_buffer_fill(buffer, 0, &msg->data[0], msg->data.size());
+        GstBuffer *buffer = gst_buffer_new_and_alloc(msg.data.size());
+        gst_buffer_fill(buffer, 0, &msg.data[0], msg.data.size());
         GstFlowReturn ret;
 
         g_signal_emit_by_name(_source, "push-buffer", buffer, &ret);


### PR DESCRIPTION
https://github.com/ros-drivers/audio_common/issues/283#issue-4893808662