### PR TITLE
remove destroy timer from SoundType object

### DIFF
--- a/sound_play/scripts/soundplay_node.py
+++ b/sound_play/scripts/soundplay_node.py
@@ -114,7 +114,6 @@ class SoundType(object):
                 self.stop()
 
     def __del__(self):
-        self.destroy_timer(self.timer)
         self.dispose()
 
     def update(self):


### PR DESCRIPTION
On destroy of SoundType object. The destroyer would call destroy_timer() but SoundType is not a Node and does not own a self.timer variable.

```
[soundplay_node.py-1] [ERROR] [1784810159.668171488] [soundplay_node]: Error setting up to play "beep.wav".Does this file exist on the machine on which sound_play is running?
[soundplay_node.py-1] Exception ignored in: <function SoundType.__del__ at 0x7fff9c5a2ca0>
[soundplay_node.py-1] Traceback (most recent call last):
[soundplay_node.py-1]   File "/home/thomasung/exchange/nix-humble/install/sound_play/lib/sound_play/soundplay_node.py", line 117, in __del__
[soundplay_node.py-1]     self.destroy_timer(self.timer)
[soundplay_node.py-1] AttributeError: 'SoundType' object has no attribute 'destroy_timer'
```